### PR TITLE
Fix duplicate sidebar tab background style declaration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -845,7 +845,7 @@ function Studio({ user }) {
                 { key: "prefs", label: "環境" },
               ].map(({ key, label }) => (
                 <button key={key} onClick={() => setTab(key)} style={{
-                  padding: "14px 0", width: "100%", background: "transparent", border: "none",
+                  padding: "14px 0", width: "100%", border: "none",
                   borderBottom: "1px solid #0e1520",
                   color: tab === key ? "#7ab3e0" : "#2a4060",
                   cursor: "pointer", fontSize: 10, fontFamily: "inherit",


### PR DESCRIPTION
### Motivation
- Remove a duplicated `background` key in the sidebar tab button inline style to eliminate the duplicate-key warning while preserving the selected-tab highlighting behavior.

### Description
- Removed the redundant `background: "transparent"` entry from the sidebar tab button inline style in `src/App.jsx` and kept the conditional `background` used for the selected tab.

### Testing
- Ran `npm run build` which completed successfully, and started the dev server and captured a UI screenshot via Playwright to validate the visual state (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0e6a61c48323ae1151e9a09266ed)