### PR TITLE
Improve Google OAuth redirect handling and login feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VITE_ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_REDIRECT_TO=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ npm install
 
 # APIキーを設定
 cp .env.example .env
-# .envを編集してANTHROPIC_API_KEYを設定
+# .envを編集して必要な値を設定
+# - ANTHROPIC_API_KEY
+# - VITE_SUPABASE_URL
+# - VITE_SUPABASE_ANON_KEY
+# - VITE_SUPABASE_REDIRECT_TO（Supabaseの認証URL許可リストと一致させる）
 
 # 開発サーバー起動
 npm run dev
@@ -63,3 +67,9 @@ APIキーはフロントエンドに含まれるため、**自分専用の閉じ
 
 - ブラウザのlocalStorageに保存
 - クリアすると消えるので定期的に「出力」からバックアップを
+
+## Google認証が戻ってこないとき
+
+- `.env` の `VITE_SUPABASE_REDIRECT_TO` を、実際に開いているURL（例: `https://your-domain.com/`）に設定してください。
+- Supabaseダッシュボードの **Authentication > URL Configuration > Redirect URLs** に同じURLを登録してください。
+- URLが完全一致していないと、Google認証後にアプリへ復帰できません。

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -322,6 +322,26 @@ body { display:flex; align-items:stretch; padding:20px; }
 export default function App() {
   const [user, setUser] = useState(null);
   const [authLoading, setAuthLoading] = useState(true);
+  const [authError, setAuthError] = useState("");
+  const [signingIn, setSigningIn] = useState(false);
+
+  const handleGoogleSignIn = async () => {
+    setAuthError("");
+    setSigningIn(true);
+
+    const redirectTo = import.meta.env.VITE_SUPABASE_REDIRECT_TO
+      || `${window.location.origin}${window.location.pathname}`;
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo },
+    });
+
+    if (error) {
+      setAuthError(`ログイン開始に失敗しました: ${error.message}`);
+      setSigningIn(false);
+    }
+  };
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -354,10 +374,14 @@ export default function App() {
         <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textAlign: "center", marginTop: 4 }}>minato ws</div>
       </div>
       <div style={{ fontSize: 18, color: "#c8d8e8", fontWeight: 700, fontFamily: "'Noto Serif JP','Georgia',serif", letterSpacing: 1 }}>港に届いた例外</div>
-      <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{
+      <button onClick={handleGoogleSignIn} disabled={signingIn} style={{
         padding: "10px 28px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5",
-        color: "#7ab3e0", cursor: "pointer", borderRadius: 6, fontSize: 13, fontFamily: "inherit", letterSpacing: 1,
-      }}>Googleでログイン</button>
+        color: "#7ab3e0", cursor: signingIn ? "default" : "pointer", borderRadius: 6, fontSize: 13, fontFamily: "inherit", letterSpacing: 1,
+        opacity: signingIn ? 0.7 : 1,
+      }}>{signingIn ? "Google認証へ接続中…" : "Googleでログイン"}</button>
+      {authError && (
+        <div style={{ maxWidth: 420, color: "#d68585", fontSize: 12, lineHeight: 1.6, textAlign: "center" }}>{authError}</div>
+      )}
     </div>
   );
 
@@ -845,7 +869,7 @@ function Studio({ user }) {
                 { key: "prefs", label: "環境" },
               ].map(({ key, label }) => (
                 <button key={key} onClick={() => setTab(key)} style={{
-                  padding: "14px 0", width: "100%", background: "transparent", border: "none",
+                  padding: "14px 0", width: "100%", border: "none",
                   borderBottom: "1px solid #0e1520",
                   color: tab === key ? "#7ab3e0" : "#2a4060",
                   cursor: "pointer", fontSize: 10, fontFamily: "inherit",


### PR DESCRIPTION
### Motivation
- Users were not reliably returning to the app after completing Google OAuth with Supabase, commonly caused by redirect URL mismatches. 
- The login UI provided no feedback when the OAuth launch failed or was in progress.

### Description
- Added `handleGoogleSignIn` in `src/App.jsx` to centralize Google OAuth launches and prefer `VITE_SUPABASE_REDIRECT_TO` with a fallback to `window.location.origin + window.location.pathname`.
- Added `authError` and `signingIn` state in `src/App.jsx` and updated the login button to disable while launching and show an error message on `signInWithOAuth` failure.
- Updated `.env.example` to include `VITE_SUPABASE_REDIRECT_TO` and extended `README.md` with instructions to register the same URL in Supabase Auth redirect settings.
- Minor UI tweak to sidebar collapsed tab styles to avoid the redundant `background` declaration while preserving selected-tab highlighting.

### Testing
- Ran `npm run build`, which completed successfully and produced a build.
- Started the dev server with `npm run dev`, which launched and served the app locally.
- Attempted to capture a login-screen screenshot with Playwright, but the Chromium process crashed in this environment (SIGSEGV), so UI screenshot validation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0e6a61c48323ae1151e9a09266ed)