### PR TITLE
Fix duplicate inline style key warning in App sidebar tab buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -845,7 +845,7 @@ function Studio({ user }) {
                 { key: "prefs", label: "環境" },
               ].map(({ key, label }) => (
                 <button key={key} onClick={() => setTab(key)} style={{
-                  padding: "14px 0", width: "100%", background: "transparent", border: "none",
+                  padding: "14px 0", width: "100%", border: "none",
                   borderBottom: "1px solid #0e1520",
                   color: tab === key ? "#7ab3e0" : "#2a4060",
                   cursor: "pointer", fontSize: 10, fontFamily: "inherit",


### PR DESCRIPTION
### Motivation
- ビルド時に inline style オブジェクト内で重複した `background` キーによる Vite/esbuild の警告が出ていたため、警告を解消してコードの健全性を高める目的で修正しました。

### Description
- `src/App.jsx` の折りたたみサイドバーのタブボタンにある inline style から重複していた `background` プロパティを削除する小さな差分を適用しました（表示や挙動の変更はありません）。

### Testing
- `npm run build` を実行してビルドが成功し、重複キー警告が出力されなくなったことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c465a6acc832387521b0c0dfc5893)