### PR TITLE
fix: 開発環境でAI呼び出しが失敗する問題を修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-VITE_ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx
+ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
   plugins: [
     react(),
     VitePWA({
@@ -48,10 +50,12 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/anthropic/, ""),
         headers: {
+          "x-api-key": env.ANTHROPIC_API_KEY ?? "",
           "anthropic-version": "2023-06-01",
           "anthropic-dangerous-direct-browser-access": "true"
         }
       }
     }
   }
+  };
 });


### PR DESCRIPTION
- vite.config.js: loadEnvでANTHROPIC_API_KEYを読み込み、 Vite proxyのヘッダにx-api-keyを付与するよう修正
- .env.example: VITE_ANTHROPIC_API_KEYをANTHROPIC_API_KEYに変更し 本番（api/anthropic.js）と変数名を統一 （VITE_プレフィックスはブラウザバンドルへの露出リスクもあるため除去）

https://claude.ai/code/session_01CMz1eAwkQAMS1YyToJXwDe