### PR TITLE
AIメニュー自由指示・執筆欄高さ維持・構成ドラッグ移動・退出ボタン統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,6 +206,7 @@ function Studio({ user }: { user: User }) {
           {tab === "structure" && (
             <StructureView
               scenes={scenes}
+              setScenes={setScenes}
               manuscripts={manuscripts}
               addingScene={addingScene}
               setAddingScene={setAddingScene}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -64,7 +64,7 @@ export const Header: React.FC<HeaderProps> = ({
         <button onClick={() => saveWithBackup(scenes, settings, manuscripts, projectTitle)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>保存</button>
         <button onClick={() => setShowBackups(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>履歴</button>
         <button onClick={() => setShowExport(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>出力</button>
-        <button onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#2a3548", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>ログアウト</button>
+        <button onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>退出</button>
       </div>
     </header>
   );

--- a/src/components/views/WriteView.tsx
+++ b/src/components/views/WriteView.tsx
@@ -52,7 +52,7 @@ export const WriteView: React.FC<WriteViewProps> = ({
   }
 
   return (
-    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "16px 12px" }}>
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "16px 12px", overflowY: "auto" }}>
       <div style={{ position: "relative", marginBottom: 12 }}>
         <div style={{ paddingRight: 0 }}>
           <div style={{ fontSize: 11, color: "#3a5570", letterSpacing: 2, marginBottom: 4 }}>{selectedScene.chapter}</div>
@@ -103,7 +103,7 @@ export const WriteView: React.FC<WriteViewProps> = ({
           lineHeight={editorSettings.lineHeight}
         />
       ) : (
-        <textarea value={manuscriptText} onChange={e => handleManuscriptChange(e.target.value)} placeholder="ここに本文を書く…" style={{ flex: 1, minHeight: 400, background: "#070a14", border: "1px solid #1a2535", color: "#c8d8e8", fontFamily: "'Noto Serif JP','Georgia',serif", fontSize: editorSettings.fontSize, lineHeight: editorSettings.lineHeight, padding: "16px 12px", resize: "none", outline: "none", borderRadius: 6, width: "100%", boxSizing: "border-box" }} />
+        <textarea value={manuscriptText} onChange={e => handleManuscriptChange(e.target.value)} placeholder="ここに本文を書く…" style={{ flexGrow: 1, flexShrink: 0, minHeight: 400, background: "#070a14", border: "1px solid #1a2535", color: "#c8d8e8", fontFamily: "'Noto Serif JP','Georgia',serif", fontSize: editorSettings.fontSize, lineHeight: editorSettings.lineHeight, padding: "16px 12px", resize: "none", outline: "none", borderRadius: 6, width: "100%", boxSizing: "border-box" }} />
       )}
       <div style={{ marginTop: 6, display: "flex", alignItems: "center", paddingRight: 90 }}>
         {(() => {

--- a/src/hooks/useStudioState.ts
+++ b/src/hooks/useStudioState.ts
@@ -101,9 +101,9 @@ export function useStudioState(_user: User) {
   const [editorSettings, setEditorSettings] = useState<EditorSettings>({ fontSize: 15, lineHeight: 2.2 });
   const [aiFloat, setAiFloat] = useState(false);
   const [aiWide, setAiWide] = useState(false);
-  const [aiResults, setAiResults] = useState<AiResults>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "" });
-  const [aiErrors, setAiErrors] = useState<AiErrors>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "" });
-  const [aiLoading, setAiLoading] = useState<AiLoading>({ polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false });
+  const [aiResults, setAiResults] = useState<AiResults>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" });
+  const [aiErrors, setAiErrors] = useState<AiErrors>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" });
+  const [aiLoading, setAiLoading] = useState<AiLoading>({ polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false });
   const [aiApplied, setAiApplied] = useState<AppliedState>({});
   const [hintApplied, setHintApplied] = useState<AppliedState>({});
   const [exportContent, setExportContent] = useState<string>("");

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type AiResults = {
   continue: string;
   synopsis: string;
   worldExpand: string;
+  freeInstruct: string;
 };
 
 export type AiErrors = Record<keyof AiResults, string>;


### PR DESCRIPTION
- AiAssistant: AIメニューパネルの先頭に自由指示セクションを追加（テキスト入力→実行→追記）
- WriteView: 続きを提案結果表示後も執筆欄が縮まないようflexGrow/flexShrink設定とoverflowY:autoを追加
- StructureView: シーンにdraggable属性とdrag&dropハンドラを追加、章をまたいだシーン移動に対応
- Header: ログアウトボタンを他ボタンと同スタイル・文言「退出」に統一
- types/useStudioState: AiResultsにfreeInstructキーを追加

https://claude.ai/code/session_01RHZiQdRfXcEron1Zzu3p1h