### PR TITLE
AIフッター折り畳み・同一章D&D修正・自由指示保持・AI履歴・2系統バックアップ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ function Studio({ user }: { user: User }) {
     selectedScene, manuscriptText, wordCount,
     handleSceneSelect, handleManuscriptChange, handleStatusChange, handleAddScene,
     handleDeleteScene, confirmDeleteExecute, saveWithBackup, exportScene, exportAll,
-    handleSaveBackup
+    handleSaveBackup, aiHistory, addAiHistory, clearAiHistory, autoBackups,
   } = useStudioState(user);
 
   if (!loaded) return (
@@ -113,6 +113,7 @@ function Studio({ user }: { user: User }) {
       {showBackups && (
         <BackupModal
           backups={backups}
+          autoBackups={autoBackups}
           _scenes={scenes}
           _settings={settings}
           _manuscripts={manuscripts}
@@ -171,6 +172,9 @@ function Studio({ user }: { user: User }) {
           setEditorSettings={setEditorSettings}
           handleSceneSelect={handleSceneSelect}
           handleAddScene={handleAddScene}
+          aiHistory={aiHistory}
+          onInsertHistory={(content) => handleManuscriptChange(manuscriptText + (manuscriptText ? "\n" : "") + content)}
+          onClearHistory={clearAiHistory}
         />
 
         <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
@@ -200,6 +204,7 @@ function Studio({ user }: { user: User }) {
               aiLoading={aiLoading}
               setAiLoading={setAiLoading}
               settings={settings}
+              addAiHistory={addAiHistory}
             />
           )}
 
@@ -267,6 +272,7 @@ function Studio({ user }: { user: User }) {
           handleManuscriptChange={handleManuscriptChange}
           settings={settings}
           selectedScene={selectedScene}
+          addAiHistory={addAiHistory}
         />
         </ErrorBoundary>
       )}

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -29,6 +29,7 @@ interface AiAssistantProps {
   handleManuscriptChange: (text: string) => void;
   settings: Settings;
   selectedScene: Scene | null;
+  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
 }
 
 export const AiAssistant: React.FC<AiAssistantProps> = ({
@@ -37,7 +38,7 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
   aiErrors, setAiErrors,
   aiLoading, setAiLoading, aiApplied, setAiApplied,
   hintApplied, setHintApplied, manuscriptText,
-  handleManuscriptChange, settings, selectedScene
+  handleManuscriptChange, settings, selectedScene, addAiHistory
 }) => {
   const [freeText, setFreeText] = useState("");
 
@@ -50,6 +51,7 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
     try {
       const text = await callAnthropic(context);
       setAiResults(r => ({ ...r, freeInstruct: text }));
+      if (text) addAiHistory("自由指示", text, selectedScene?.title);
     } catch (e) {
       if (e instanceof AiError) {
         setAiErrors(er => ({ ...er, freeInstruct: e.message }));
@@ -133,7 +135,7 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
                     {aiResults.freeInstruct}
                     <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
                       <button
-                        onClick={() => { handleManuscriptChange(manuscriptText + "\n" + aiResults.freeInstruct); setAiResults(r => ({ ...r, freeInstruct: "" })); }}
+                        onClick={() => { handleManuscriptChange(manuscriptText + "\n" + aiResults.freeInstruct); }}
                         style={{ padding: "3px 10px", background: "rgba(42,128,96,0.15)", border: "1px solid #2a8060", color: "#5ab090", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}
                       >
                         追記
@@ -176,7 +178,7 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
               <AiPanel
                 label="矛盾チェック"
                 result={aiResults.check}
-                onResult={t => setAiResults(r => ({ ...r, check: t }))}
+                onResult={t => { setAiResults(r => ({ ...r, check: t })); if (t) addAiHistory("矛盾チェック", t, selectedScene.title); }}
                 onLoading={v => setAiLoading(l => ({ ...l, check: v }))}
                 loading={aiLoading.check}
                 error={aiErrors.check}

--- a/src/components/modals/BackupModal.tsx
+++ b/src/components/modals/BackupModal.tsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Scene, Settings, Manuscripts, Backup } from "../../types";
 
 type BackupModalProps = {
   backups: Backup[];
+  autoBackups: Backup[];
   _scenes: Scene[];
   _settings: Settings;
   _manuscripts: Manuscripts;
@@ -13,6 +14,7 @@ type BackupModalProps = {
 
 export function BackupModal({
   backups,
+  autoBackups,
   _scenes,
   _settings,
   _manuscripts,
@@ -21,6 +23,9 @@ export function BackupModal({
   onClose,
 }: BackupModalProps) {
   const backupLabelRef = useRef<HTMLInputElement>(null);
+  const [track, setTrack] = useState<"manual" | "auto">("manual");
+
+  const list = track === "manual" ? backups : autoBackups;
 
   return (
     <div
@@ -34,49 +39,75 @@ export function BackupModal({
         justifyContent: "center",
       }}
     >
-      <div style={{ background: "#0e1520", border: "1px solid #2a3f58", borderRadius: 8, padding: "24px 28px", maxWidth: 400, width: "90%" }}>
-        <div style={{ fontSize: 13, color: "#7ab3e0", marginBottom: 16, textAlign: "center" }}>バージョン履歴</div>
-        <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-          <input
-            ref={backupLabelRef}
-            placeholder="バージョン名（省略可）"
-            style={{
-              flex: 1,
-              background: "#070a14",
-              border: "1px solid #1e2d42",
-              color: "#8ab0cc",
-              padding: "5px 10px",
-              borderRadius: 4,
-              fontSize: 12,
-              fontFamily: "inherit",
-              outline: "none",
-            }}
-          />
-          <button
-            onClick={() => {
-              const label = backupLabelRef.current?.value || null;
-              onSaveBackup(label);
-              if (backupLabelRef.current) backupLabelRef.current.value = "";
-            }}
-            style={{
-              padding: "5px 14px",
-              background: "rgba(74,111,165,0.2)",
-              border: "1px solid #4a6fa5",
-              color: "#7ab3e0",
-              cursor: "pointer",
-              borderRadius: 4,
-              fontSize: 12,
-              fontFamily: "inherit",
-            }}
-          >
-            記録
-          </button>
+      <div style={{ background: "#0e1520", border: "1px solid #2a3f58", borderRadius: 8, padding: "24px 28px", maxWidth: 420, width: "90%" }}>
+        <div style={{ fontSize: 13, color: "#7ab3e0", marginBottom: 14, textAlign: "center" }}>バージョン履歴</div>
+
+        {/* トラック切り替え */}
+        <div style={{ display: "flex", gap: 6, marginBottom: 14 }}>
+          {(["manual", "auto"] as const).map(t => (
+            <button
+              key={t}
+              onClick={() => setTrack(t)}
+              style={{
+                flex: 1, padding: "5px", background: track === t ? "rgba(74,111,165,0.2)" : "transparent",
+                border: "1px solid", borderColor: track === t ? "#4a6fa5" : "#1e2d42",
+                color: track === t ? "#7ab3e0" : "#3a5570",
+                cursor: "pointer", borderRadius: 4, fontSize: 11, fontFamily: "inherit",
+              }}
+            >
+              {t === "manual" ? "手動（5件）" : "自動（5件）"}
+            </button>
+          ))}
         </div>
-        {backups.length === 0 ? (
+
+        {/* 手動トラックのみ「記録」ボタンを表示 */}
+        {track === "manual" && (
+          <div style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+            <input
+              ref={backupLabelRef}
+              placeholder="バージョン名（省略可）"
+              style={{
+                flex: 1,
+                background: "#070a14",
+                border: "1px solid #1e2d42",
+                color: "#8ab0cc",
+                padding: "5px 10px",
+                borderRadius: 4,
+                fontSize: 12,
+                fontFamily: "inherit",
+                outline: "none",
+              }}
+            />
+            <button
+              onClick={() => {
+                const label = backupLabelRef.current?.value || null;
+                onSaveBackup(label);
+                if (backupLabelRef.current) backupLabelRef.current.value = "";
+              }}
+              style={{
+                padding: "5px 14px",
+                background: "rgba(74,111,165,0.2)",
+                border: "1px solid #4a6fa5",
+                color: "#7ab3e0",
+                cursor: "pointer",
+                borderRadius: 4,
+                fontSize: 12,
+                fontFamily: "inherit",
+              }}
+            >
+              記録
+            </button>
+          </div>
+        )}
+        {track === "auto" && (
+          <div style={{ fontSize: 10, color: "#2a4060", marginBottom: 14, textAlign: "center" }}>10分ごとに自動記録（最新5件）</div>
+        )}
+
+        {list.length === 0 ? (
           <div style={{ fontSize: 12, color: "#3a5570", textAlign: "center", marginBottom: 20 }}>まだバックアップがありません</div>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
-            {backups.map((bk, i) => {
+            {list.map((bk, i) => {
               const d = new Date(bk.timestamp);
               const timeLabel = `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
               const charCount = Object.values(bk.manuscripts || {}).reduce((a, t) => a + t.replace(/\s/g, "").length, 0);

--- a/src/components/views/StructureView.tsx
+++ b/src/components/views/StructureView.tsx
@@ -48,6 +48,7 @@ export const StructureView: React.FC<StructureViewProps> = ({
 
   const handleDragOverScene = (e: React.DragEvent, sceneId: number) => {
     e.preventDefault();
+    e.stopPropagation();
     e.dataTransfer.dropEffect = "move";
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const position = e.clientY < rect.top + rect.height / 2 ? "before" : "after";
@@ -64,6 +65,7 @@ export const StructureView: React.FC<StructureViewProps> = ({
 
   const handleDropOnScene = (e: React.DragEvent, targetId: number, targetChapter: string) => {
     e.preventDefault();
+    e.stopPropagation();
     if (!draggingId || draggingId === targetId) {
       setDropTarget(null);
       return;

--- a/src/components/views/WriteView.tsx
+++ b/src/components/views/WriteView.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { VerticalEditor } from "../editor/VerticalEditor";
 import { AiPanel } from "../ai/AiPanel";
 import { statusColors, statusLabels } from "../../constants";
@@ -31,6 +31,7 @@ interface WriteViewProps {
   aiLoading: AiLoading;
   setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
   settings: Settings;
+  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
 }
 
 export const WriteView: React.FC<WriteViewProps> = ({
@@ -41,8 +42,10 @@ export const WriteView: React.FC<WriteViewProps> = ({
   handleDeleteScene, manuscriptText, handleManuscriptChange,
   editorSettings, handleSceneSelect, wordCount,
   aiResults, setAiResults, aiErrors, setAiErrors,
-  aiLoading, setAiLoading, settings
+  aiLoading, setAiLoading, settings, addAiHistory
 }) => {
+  const [footerOpen, setFooterOpen] = useState(true);
+
   if (!selectedScene) {
     return (
       <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#1e2d42", fontSize: 14 }}>
@@ -52,97 +55,112 @@ export const WriteView: React.FC<WriteViewProps> = ({
   }
 
   return (
-    <div style={{ flex: 1, display: "flex", flexDirection: "column", padding: "16px 12px", overflowY: "auto" }}>
-      <div style={{ position: "relative", marginBottom: 12 }}>
-        <div style={{ paddingRight: 0 }}>
-          <div style={{ fontSize: 11, color: "#3a5570", letterSpacing: 2, marginBottom: 4 }}>{selectedScene.chapter}</div>
-          {editingSceneTitle ? (
-            <input
-              autoFocus
-              value={selectedScene.title}
-              onChange={e => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, title: e.target.value } : s))}
-              onBlur={() => setEditingSceneTitle(false)}
-              onKeyDown={e => e.key === "Enter" && setEditingSceneTitle(false)}
-              style={{ margin: 0, fontSize: 20, fontWeight: 600, color: "#c8d8e8", background: "transparent", border: "none", borderBottom: "1px solid #4a6fa5", outline: "none", fontFamily: "'Noto Serif JP','Georgia',serif", width: "100%", letterSpacing: 1 }}
-            />
-          ) : (
-            <h2 onClick={() => setEditingSceneTitle(true)} style={{ margin: 0, fontSize: 20, color: "#c8d8e8", fontWeight: 600, cursor: "text" }} title="クリックで編集">
-              {selectedScene.title ? selectedScene.title : <span style={{ fontStyle: "italic", color: "#3a5570" }}>無題</span>}
-            </h2>
-          )}
-          {editingSceneSynopsis ? (
-            <input
-              autoFocus
-              value={selectedScene.synopsis || ""}
-              onChange={e => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, synopsis: e.target.value } : s))}
-              onBlur={() => setEditingSceneSynopsis(false)}
-              onKeyDown={e => e.key === "Enter" && setEditingSceneSynopsis(false)}
-              placeholder="概要を入力…"
-              style={{ marginTop: 4, fontSize: 12, color: "#8ab0cc", background: "transparent", border: "none", borderBottom: "1px solid #2a4060", outline: "none", fontFamily: "inherit", width: "100%", fontStyle: "italic" }}
-            />
-          ) : (
-            <div onClick={() => setEditingSceneSynopsis(true)} style={{ marginTop: 4, fontSize: 12, color: selectedScene.synopsis ? "#3a5570" : "#1e2d42", fontStyle: "italic", cursor: "text", minHeight: 18 }}>
-              {selectedScene.synopsis || "概要を追加…"}
-            </div>
-          )}
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      {/* Scrollable writing area */}
+      <div style={{ flex: 1, overflowY: "auto", padding: "16px 12px", display: "flex", flexDirection: "column" }}>
+        <div style={{ position: "relative", marginBottom: 12 }}>
+          <div style={{ paddingRight: 0 }}>
+            <div style={{ fontSize: 11, color: "#3a5570", letterSpacing: 2, marginBottom: 4 }}>{selectedScene.chapter}</div>
+            {editingSceneTitle ? (
+              <input
+                autoFocus
+                value={selectedScene.title}
+                onChange={e => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, title: e.target.value } : s))}
+                onBlur={() => setEditingSceneTitle(false)}
+                onKeyDown={e => e.key === "Enter" && setEditingSceneTitle(false)}
+                style={{ margin: 0, fontSize: 20, fontWeight: 600, color: "#c8d8e8", background: "transparent", border: "none", borderBottom: "1px solid #4a6fa5", outline: "none", fontFamily: "'Noto Serif JP','Georgia',serif", width: "100%", letterSpacing: 1 }}
+              />
+            ) : (
+              <h2 onClick={() => setEditingSceneTitle(true)} style={{ margin: 0, fontSize: 20, color: "#c8d8e8", fontWeight: 600, cursor: "text" }} title="クリックで編集">
+                {selectedScene.title ? selectedScene.title : <span style={{ fontStyle: "italic", color: "#3a5570" }}>無題</span>}
+              </h2>
+            )}
+            {editingSceneSynopsis ? (
+              <input
+                autoFocus
+                value={selectedScene.synopsis || ""}
+                onChange={e => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, synopsis: e.target.value } : s))}
+                onBlur={() => setEditingSceneSynopsis(false)}
+                onKeyDown={e => e.key === "Enter" && setEditingSceneSynopsis(false)}
+                placeholder="概要を入力…"
+                style={{ marginTop: 4, fontSize: 12, color: "#8ab0cc", background: "transparent", border: "none", borderBottom: "1px solid #2a4060", outline: "none", fontFamily: "inherit", width: "100%", fontStyle: "italic" }}
+              />
+            ) : (
+              <div onClick={() => setEditingSceneSynopsis(true)} style={{ marginTop: 4, fontSize: 12, color: selectedScene.synopsis ? "#3a5570" : "#1e2d42", fontStyle: "italic", cursor: "text", minHeight: 18 }}>
+                {selectedScene.synopsis || "概要を追加…"}
+              </div>
+            )}
+          </div>
+          <div style={{ position: "absolute", top: 0, right: 0, display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            {(["empty", "draft", "done"] as const).map(s => (
+              <button key={s} onClick={() => handleStatusChange(selectedScene.id, s)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: selectedScene.status === s ? statusColors[s] : "#1e2d42", background: selectedScene.status === s ? `${statusColors[s]}22` : "transparent", color: selectedScene.status === s ? statusColors[s] : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>{statusLabels[s]}</button>
+            ))}
+            <button onClick={() => setVerticalPreview(!verticalPreview)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: verticalPreview ? "#4a6fa5" : "#1e2d42", background: verticalPreview ? "rgba(74,111,165,0.15)" : "transparent", color: verticalPreview ? "#7ab3e0" : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>縦組</button>
+            <button onClick={() => handleDeleteScene(selectedScene.id)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid #1e2d42", background: "transparent", color: "#3a2020", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>削除</button>
+          </div>
         </div>
-        <div style={{ position: "absolute", top: 0, right: 0, display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
-          {(["empty", "draft", "done"] as const).map(s => (
-            <button key={s} onClick={() => handleStatusChange(selectedScene.id, s)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: selectedScene.status === s ? statusColors[s] : "#1e2d42", background: selectedScene.status === s ? `${statusColors[s]}22` : "transparent", color: selectedScene.status === s ? statusColors[s] : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>{statusLabels[s]}</button>
-          ))}
-          <button onClick={() => setVerticalPreview(!verticalPreview)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: verticalPreview ? "#4a6fa5" : "#1e2d42", background: verticalPreview ? "rgba(74,111,165,0.15)" : "transparent", color: verticalPreview ? "#7ab3e0" : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>縦組</button>
-          <button onClick={() => handleDeleteScene(selectedScene.id)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid #1e2d42", background: "transparent", color: "#3a2020", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>削除</button>
+        {verticalPreview ? (
+          <VerticalEditor
+            key={selectedSceneId}
+            initialText={manuscriptText}
+            onChange={handleManuscriptChange}
+            fontSize={editorSettings.fontSize}
+            lineHeight={editorSettings.lineHeight}
+          />
+        ) : (
+          <textarea value={manuscriptText} onChange={e => handleManuscriptChange(e.target.value)} placeholder="ここに本文を書く…" style={{ flex: 1, minHeight: 400, background: "#070a14", border: "1px solid #1a2535", color: "#c8d8e8", fontFamily: "'Noto Serif JP','Georgia',serif", fontSize: editorSettings.fontSize, lineHeight: editorSettings.lineHeight, padding: "16px 12px", resize: "none", outline: "none", borderRadius: 6, width: "100%", boxSizing: "border-box" }} />
+        )}
+        <div style={{ marginTop: 6, display: "flex", alignItems: "center", paddingRight: 90 }}>
+          {(() => {
+            const idx = scenes.findIndex(s => s.id === selectedSceneId);
+            const prev = scenes[idx - 1];
+            const next = scenes[idx + 1];
+            return (<>
+              <button onClick={() => prev && handleSceneSelect(prev)} disabled={!prev} style={{ padding: "4px 10px", background: "transparent", border: "1px solid", borderColor: prev ? "#1e2d42" : "#0e1520", color: prev ? "#3a5570" : "#1a2535", cursor: prev ? "pointer" : "default", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>← {prev ? (prev.title || "無題") : "—"}</button>
+              <div style={{ flex: 1, textAlign: "center", fontSize: 11, color: "#2a4060" }}>{wordCount.toLocaleString()} 文字</div>
+              <button onClick={() => next && handleSceneSelect(next)} disabled={!next} style={{ padding: "4px 10px", background: "transparent", border: "1px solid", borderColor: next ? "#1e2d42" : "#0e1520", color: next ? "#3a5570" : "#1a2535", cursor: next ? "pointer" : "default", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>{next ? (next.title || "無題") : "—"} →</button>
+            </>);
+          })()}
         </div>
-      </div>
-      {verticalPreview ? (
-        <VerticalEditor
-          key={selectedSceneId}
-          initialText={manuscriptText}
-          onChange={handleManuscriptChange}
-          fontSize={editorSettings.fontSize}
-          lineHeight={editorSettings.lineHeight}
-        />
-      ) : (
-        <textarea value={manuscriptText} onChange={e => handleManuscriptChange(e.target.value)} placeholder="ここに本文を書く…" style={{ flexGrow: 1, flexShrink: 0, minHeight: 400, background: "#070a14", border: "1px solid #1a2535", color: "#c8d8e8", fontFamily: "'Noto Serif JP','Georgia',serif", fontSize: editorSettings.fontSize, lineHeight: editorSettings.lineHeight, padding: "16px 12px", resize: "none", outline: "none", borderRadius: 6, width: "100%", boxSizing: "border-box" }} />
-      )}
-      <div style={{ marginTop: 6, display: "flex", alignItems: "center", paddingRight: 90 }}>
-        {(() => {
-          const idx = scenes.findIndex(s => s.id === selectedSceneId);
-          const prev = scenes[idx - 1];
-          const next = scenes[idx + 1];
-          return (<>
-            <button onClick={() => prev && handleSceneSelect(prev)} disabled={!prev} style={{ padding: "4px 10px", background: "transparent", border: "1px solid", borderColor: prev ? "#1e2d42" : "#0e1520", color: prev ? "#3a5570" : "#1a2535", cursor: prev ? "pointer" : "default", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>← {prev ? (prev.title || "無題") : "—"}</button>
-            <div style={{ flex: 1, textAlign: "center", fontSize: 11, color: "#2a4060" }}>{wordCount.toLocaleString()} 文字</div>
-            <button onClick={() => next && handleSceneSelect(next)} disabled={!next} style={{ padding: "4px 10px", background: "transparent", border: "1px solid", borderColor: next ? "#1e2d42" : "#0e1520", color: next ? "#3a5570" : "#1a2535", cursor: next ? "pointer" : "default", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>{next ? (next.title || "無題") : "—"} →</button>
-          </>);
-        })()}
       </div>
 
-      <div style={{ borderTop: "1px solid #0e1520", padding: "8px 0", marginTop: 12, display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <AiPanel
-          label="続きを提案"
-          compact
-          result={aiResults.continue || ""}
-          onResult={t => setAiResults(r => ({ ...r, continue: t }))}
-          onLoading={v => setAiLoading(l => ({ ...l, continue: v }))}
-          loading={aiLoading.continue}
-          error={aiErrors.continue}
-          onError={t => setAiErrors(e => ({ ...e, continue: t }))}
-          prompt={`以下の小説のシーンの続きを200字程度で提案してください。世界観・文体を維持し、あくまで提案として。\n\n【世界観】${settings.world}\n【シーン】${selectedScene.chapter} / ${selectedScene.title}\n【概要】${selectedScene.synopsis || ""}\n【本文末尾】${manuscriptText.slice(-200)}`}
-          onAppend={text => handleManuscriptChange(manuscriptText + "\n" + text)}
-        />
-        <AiPanel
-          label="概要を自動生成"
-          compact
-          result={aiResults.synopsis || ""}
-          onResult={t => setAiResults(r => ({ ...r, synopsis: t }))}
-          onLoading={v => setAiLoading(l => ({ ...l, synopsis: v }))}
-          loading={aiLoading.synopsis}
-          error={aiErrors.synopsis}
-          onError={t => setAiErrors(e => ({ ...e, synopsis: t }))}
-          prompt={`以下の本文を読んで、シーンの概要を50字以内で生成してください。一文のみ返してください。\n\n${manuscriptText}`}
-          onAppend={text => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, synopsis: text.trim() } : s))}
-        />
+      {/* Collapsible AI footer */}
+      <div style={{ flexShrink: 0, background: "#080c16", borderTop: "1px solid #1a2535" }}>
+        <button
+          onClick={() => setFooterOpen(!footerOpen)}
+          style={{ width: "100%", padding: "5px 12px", display: "flex", alignItems: "center", background: "transparent", border: "none", cursor: "pointer", fontFamily: "inherit" }}
+        >
+          <span style={{ fontSize: 10, letterSpacing: 2, color: "#3a5570", flex: 1, textAlign: "left" }}>✦ AI</span>
+          <span style={{ color: "#2a4060", fontSize: 9 }}>{footerOpen ? "▾" : "▸"}</span>
+        </button>
+        {footerOpen && (
+          <div style={{ padding: "0 12px 8px", display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <AiPanel
+              label="続きを提案"
+              compact
+              result={aiResults.continue || ""}
+              onResult={t => { setAiResults(r => ({ ...r, continue: t })); if (t) addAiHistory("続きを提案", t, selectedScene.title); }}
+              onLoading={v => setAiLoading(l => ({ ...l, continue: v }))}
+              loading={aiLoading.continue}
+              error={aiErrors.continue}
+              onError={t => setAiErrors(e => ({ ...e, continue: t }))}
+              prompt={`以下の小説のシーンの続きを200字程度で提案してください。世界観・文体を維持し、あくまで提案として。\n\n【世界観】${settings.world}\n【シーン】${selectedScene.chapter} / ${selectedScene.title}\n【概要】${selectedScene.synopsis || ""}\n【本文末尾】${manuscriptText.slice(-200)}`}
+              onAppend={text => handleManuscriptChange(manuscriptText + "\n" + text)}
+            />
+            <AiPanel
+              label="概要を自動生成"
+              compact
+              result={aiResults.synopsis || ""}
+              onResult={t => { setAiResults(r => ({ ...r, synopsis: t })); if (t) addAiHistory("概要を自動生成", t, selectedScene.title); }}
+              onLoading={v => setAiLoading(l => ({ ...l, synopsis: v }))}
+              loading={aiLoading.synopsis}
+              error={aiErrors.synopsis}
+              onError={t => setAiErrors(e => ({ ...e, synopsis: t }))}
+              prompt={`以下の本文を読んで、シーンの概要を50字以内で生成してください。一文のみ返してください。\n\n${manuscriptText}`}
+              onAppend={text => setScenes(scenes.map(s => s.id === selectedSceneId ? { ...s, synopsis: text.trim() } : s))}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,4 +43,13 @@ export type PolishSuggestion = { original: string; suggestion: string; reason: s
 export type SceneDraft = Pick<Scene, "chapter" | "title" | "synopsis">;
 export type EditorSettings = { fontSize: number; lineHeight: number };
 export type TabKey = "write" | "structure" | "settings" | "prefs";
+export type SidebarTabKey = TabKey | "ai";
 export type SaveStatus = "saving" | "saved" | "error" | "offline";
+
+export type AiHistoryItem = {
+  id: number;
+  timestamp: string;
+  label: string;
+  content: string;
+  sceneTitle?: string;
+};


### PR DESCRIPTION
- WriteView: 続きを提案エリアを折りたたみ可能なフッターバーに変更（▸/▾トグル）、 AIフッターを別レイヤーにして執筆欄の高さが変わらないレイアウトに改善
- StructureView: dragOver/dropOnSceneにstopPropagation追加→同一章内並べ替えが正常動作
- AiAssistant: 自由指示の「追記」後も結果テキストを保持、矛盾チェック結果をAI履歴に追加
- Sidebar: AI履歴タブ（"AI"）を追加、生成された提案をプール・本文に追記可能
- BackupModal: 手動/自動の2トラック切替UI（各5件）を追加
- useStudioState: aiHistory/addAiHistory/clearAiHistory/autoBackupsを追加、 SidebarTabKey型に"ai"を追加、10分ごと自動バックアップタイマー実装
- types.ts: SidebarTabKey・AiHistoryItem型を追加

https://claude.ai/code/session_01RHZiQdRfXcEron1Zzu3p1h