### PR TITLE
Add AI history, export toast, and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
         overflow: hidden;
       }
       #root { height: 100dvh; display: flex; flex-direction: column; }
+      @keyframes fadeOut {
+        0% { opacity: 0; transform: translate(-50%, -10px); }
+        10% { opacity: 1; transform: translate(-50%, 0); }
+        80% { opacity: 1; transform: translate(-50%, 0); }
+        100% { opacity: 0; transform: translate(-50%, -10px); }
+      }
     </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,12 +75,13 @@ function Studio({ user }: { user: User }) {
     showBackups, setShowBackups, verticalPreview, setVerticalPreview,
     editingSceneTitle, setEditingSceneTitle, editingSceneSynopsis, setEditingSceneSynopsis,
     sidebarFloat, setSidebarFloat, sidebarTab, setSidebarTab, editorSettings, setEditorSettings,
-    aiFloat, setAiFloat, aiWide, setAiWide, aiResults, setAiResults, aiErrors, setAiErrors, aiLoading, setAiLoading,
+    aiFloat, setAiFloat, aiWide, setAiWide, aiResults, setAiResults, aiHistory, setAiHistory, aiErrors, setAiErrors, aiLoading, setAiLoading,
     aiApplied, setAiApplied, hintApplied, setHintApplied,
+    exportStatus, setExportStatus,
     selectedScene, manuscriptText, wordCount,
     handleSceneSelect, handleManuscriptChange, handleStatusChange, handleAddScene,
     handleDeleteScene, confirmDeleteExecute, saveWithBackup, exportScene, exportAll,
-    handleSaveBackup
+    handleSaveBackup, addAiHistory
   } = useStudioState(user);
 
   if (!loaded) return (
@@ -140,6 +141,18 @@ function Studio({ user }: { user: User }) {
         setShowExport={setShowExport}
       />
 
+      {/* Export Success Message */}
+      {exportStatus && (
+        <div style={{
+          position: "fixed", top: 60, left: "50%", transform: "translateX(-50%)",
+          zIndex: 1000, background: "rgba(42,128,96,0.9)", color: "#fff",
+          padding: "8px 20px", borderRadius: 4, fontSize: 12, boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
+          border: "1px solid #5ab090", pointerEvents: "none", animation: "fadeOut 3s forwards"
+        }}>
+          {exportStatus}
+        </div>
+      )}
+
       <div style={{ display: "flex", flex: 1, minHeight: 0, position: "relative" }}>
         {/* フロートオーバーレイ背景 */}
         {sidebarOpen && sidebarFloat && (
@@ -171,6 +184,8 @@ function Studio({ user }: { user: User }) {
           setEditorSettings={setEditorSettings}
           handleSceneSelect={handleSceneSelect}
           handleAddScene={handleAddScene}
+          aiHistory={aiHistory}
+          setAiHistory={setAiHistory}
         />
 
         <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
@@ -266,6 +281,7 @@ function Studio({ user }: { user: User }) {
           handleManuscriptChange={handleManuscriptChange}
           settings={settings}
           selectedScene={selectedScene}
+          addAiHistory={addAiHistory}
         />
         </ErrorBoundary>
       )}

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -28,6 +28,7 @@ interface AiAssistantProps {
   handleManuscriptChange: (text: string) => void;
   settings: Settings;
   selectedScene: Scene | null;
+  addAiHistory: (type: keyof AiResults, label: string, content: string) => void;
 }
 
 export const AiAssistant: React.FC<AiAssistantProps> = ({
@@ -36,7 +37,8 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
   aiErrors, setAiErrors,
   aiLoading, setAiLoading, aiApplied, setAiApplied,
   hintApplied, setHintApplied, manuscriptText,
-  handleManuscriptChange, settings, selectedScene
+  handleManuscriptChange, settings, selectedScene,
+  addAiHistory
 }) => {
   if (!selectedScene) return null;
 
@@ -66,7 +68,10 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
               <PolishPanel
                 manuscriptText={manuscriptText}
                 result={aiResults.polish}
-                onResult={t => setAiResults(r => ({ ...r, polish: t }))}
+                onResult={t => {
+                  setAiResults(r => ({ ...r, polish: t }));
+                  if (t) addAiHistory("polish", "推敲", t);
+                }}
                 loading={aiLoading.polish}
                 onLoading={v => setAiLoading(l => ({ ...l, polish: v }))}
                 error={aiErrors.polish}
@@ -82,7 +87,10 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
               />
               <HintPanel
                 result={aiResults.hint}
-                onResult={t => setAiResults(r => ({ ...r, hint: t }))}
+                onResult={t => {
+                  setAiResults(r => ({ ...r, hint: t }));
+                  if (t) addAiHistory("hint", "ヒント", t);
+                }}
                 loading={aiLoading.hint}
                 onLoading={v => setAiLoading(l => ({ ...l, hint: v }))}
                 error={aiErrors.hint}
@@ -96,7 +104,10 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
               <AiPanel
                 label="矛盾チェック"
                 result={aiResults.check}
-                onResult={t => setAiResults(r => ({ ...r, check: t }))}
+                onResult={t => {
+                  setAiResults(r => ({ ...r, check: t }));
+                  if (t) addAiHistory("check", "矛盾チェック", t);
+                }}
                 onLoading={v => setAiLoading(l => ({ ...l, check: v }))}
                 loading={aiLoading.check}
                 error={aiErrors.check}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { statusColors } from "../../constants";
 import type {
-  Scene, Manuscripts, SceneDraft, Settings, EditorSettings, TabKey
+  Scene, Manuscripts, SceneDraft, Settings, EditorSettings, TabKey, AiHistoryItem
 } from "../../types";
 
 interface SidebarProps {
@@ -30,6 +30,8 @@ interface SidebarProps {
   setEditorSettings: React.Dispatch<React.SetStateAction<EditorSettings>>;
   handleSceneSelect: (s: Scene) => void;
   handleAddScene: () => void;
+  aiHistory: AiHistoryItem[];
+  setAiHistory: (v: AiHistoryItem[]) => void;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -38,8 +40,59 @@ export const Sidebar: React.FC<SidebarProps> = ({
   manuscripts, sceneSearch, setSceneSearch, newScene, setNewScene,
   addingScene, setAddingScene, addingChapter, setAddingChapter,
   settings, setSettings, editorSettings, setEditorSettings,
-  handleSceneSelect, handleAddScene
+  handleSceneSelect, handleAddScene, aiHistory, setAiHistory
 }) => {
+  const [expandedHistory, setExpandedHistory] = useState<Record<string, boolean>>({});
+
+  const toggleExpand = (id: string) => {
+    setExpandedHistory(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const renderAiHistory = (compact: boolean) => (
+    <div style={{ marginTop: "auto", borderTop: "1px solid #1e2d42", background: "#060912" }}>
+      {!compact && (
+        <div style={{ padding: "8px 12px", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5" }}>AI HISTORY</div>
+          {aiHistory.length > 0 && (
+            <button onClick={() => setAiHistory([])} style={{ background: "transparent", border: "none", color: "#2a4060", fontSize: 9, cursor: "pointer" }}>消去</button>
+          )}
+        </div>
+      )}
+      <div style={{ maxHeight: compact ? "none" : 200, overflowY: "auto" }}>
+        {aiHistory.length === 0 && !compact && (
+          <div style={{ padding: "0 12px 12px", fontSize: 10, color: "#2a4060" }}>履歴なし</div>
+        )}
+        {aiHistory.map(item => {
+          const isExpanded = expandedHistory[item.id];
+          return (
+            <div key={item.id} style={{ borderBottom: "1px solid #0e1520", padding: compact ? "8px 4px" : "8px 12px" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 4 }}>
+                <div style={{ fontSize: 9, color: "#4a6fa5", fontWeight: "bold", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {item.label}
+                </div>
+                {!compact && (
+                  <button onClick={() => toggleExpand(item.id)} style={{ background: "transparent", border: "none", color: "#3a5570", cursor: "pointer", fontSize: 10 }}>
+                    {isExpanded ? "▲" : "▼"}
+                  </button>
+                )}
+              </div>
+              {!compact && isExpanded && (
+                <div style={{ fontSize: 11, color: "#8ab0cc", marginTop: 4, whiteSpace: "pre-wrap", lineHeight: 1.6, background: "#0a0e1a", padding: 6, borderRadius: 3, border: "1px solid #1a2535" }}>
+                  {item.content}
+                </div>
+              )}
+              {compact && (
+                <div onClick={() => { setSidebarOpen(true); toggleExpand(item.id); }} style={{ cursor: "pointer", fontSize: 14, color: "#2a4060", textAlign: "center", marginTop: 2 }} title={item.label}>
+                  ✦
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
   return (
     <aside style={{
       width: sidebarOpen ? 220 : 36,
@@ -55,142 +108,145 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }}>
       {sidebarOpen ? (
         <>
-          {/* Sidebar header: tabs + close */}
-          <div style={{ display: "flex", alignItems: "center", borderBottom: "1px solid #1e2d42", flexShrink: 0 }}>
-            {[["write","執筆"],["structure","構成"],["settings","世界観"],["prefs","環境"]].map(([key, label]) => (
-              <button key={key} onClick={() => setSidebarTab(key as TabKey)} style={{
-                flex: 1, padding: "8px 0", background: "transparent", border: "none",
-                borderBottom: sidebarTab === key ? "2px solid #4a6fa5" : "2px solid transparent",
-                color: sidebarTab === key ? "#7ab3e0" : "#2a4060",
-                cursor: "pointer", fontSize: 10, fontFamily: "inherit", letterSpacing: 1,
-              }}>{label}</button>
-            ))}
-            <button onClick={() => setSidebarFloat(!sidebarFloat)} style={{ padding: "8px 8px", background: "transparent", border: "none", borderLeft: "1px solid #1e2d42", color: sidebarFloat ? "#4a6fa5" : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit", flexShrink: 0 }} title={sidebarFloat ? "固定表示に切替" : "フロート表示に切替"}>{sidebarFloat ? "浮" : "固"}</button>
-            <button onClick={() => setSidebarOpen(false)} style={{ padding: "8px 10px", background: "transparent", border: "none", borderLeft: "1px solid #1e2d42", color: "#2a4060", cursor: "pointer", fontSize: 11, fontFamily: "inherit", flexShrink: 0 }}>◀</button>
-          </div>
-
-          {/* Sidebar content: 執筆 = scene list */}
-          {sidebarTab === "write" && <>
-            <div style={{ padding: "8px 12px 4px" }}>
-              <input
-                placeholder="シーンを検索…"
-                value={sceneSearch}
-                onChange={e => setSceneSearch(e.target.value)}
-                style={{ width: "100%", background: "#0e1520", border: "1px solid #1e2d42", color: "#8ab0cc", padding: "5px 8px", borderRadius: 4, fontSize: 11, fontFamily: "inherit", outline: "none", boxSizing: "border-box" }}
-              />
+          <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto" }}>
+            {/* Sidebar header: tabs + close */}
+            <div style={{ display: "flex", alignItems: "center", borderBottom: "1px solid #1e2d42", flexShrink: 0 }}>
+              {[["write","執筆"],["structure","構成"],["settings","世界観"],["prefs","環境"]].map(([key, label]) => (
+                <button key={key} onClick={() => setSidebarTab(key as TabKey)} style={{
+                  flex: 1, padding: "8px 0", background: "transparent", border: "none",
+                  borderBottom: sidebarTab === key ? "2px solid #4a6fa5" : "2px solid transparent",
+                  color: sidebarTab === key ? "#7ab3e0" : "#2a4060",
+                  cursor: "pointer", fontSize: 10, fontFamily: "inherit", letterSpacing: 1,
+                }}>{label}</button>
+              ))}
+              <button onClick={() => setSidebarFloat(!sidebarFloat)} style={{ padding: "8px 8px", background: "transparent", border: "none", borderLeft: "1px solid #1e2d42", color: sidebarFloat ? "#4a6fa5" : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit", flexShrink: 0 }} title={sidebarFloat ? "固定表示に切替" : "フロート表示に切替"}>{sidebarFloat ? "浮" : "固"}</button>
+              <button onClick={() => setSidebarOpen(false)} style={{ padding: "8px 10px", background: "transparent", border: "none", borderLeft: "1px solid #1e2d42", color: "#2a4060", cursor: "pointer", fontSize: 11, fontFamily: "inherit", flexShrink: 0 }}>◀</button>
             </div>
-            <div style={{ padding: "4px 16px 4px", fontSize: 10, letterSpacing: 3, color: "#2a4060", textTransform: "uppercase" }}>Scene List</div>
-            {scenes.filter(s => !sceneSearch || (s.title || "無題").includes(sceneSearch) || (s.chapter || "").includes(sceneSearch)).map(scene => (
-              <div key={scene.id} onClick={() => handleSceneSelect(scene)} style={{ padding: "10px 16px", cursor: "pointer", borderLeft: selectedSceneId === scene.id ? "2px solid #4a6fa5" : "2px solid transparent", background: selectedSceneId === scene.id ? "rgba(74,111,165,0.08)" : "transparent", borderBottom: "1px solid #0e1520" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 3 }}>
-                  <span style={{ width: 7, height: 7, borderRadius: "50%", flexShrink: 0, background: statusColors[scene.status], boxShadow: `0 0 6px ${statusColors[scene.status]}66` }} />
-                  <span style={{ fontSize: 10, color: "#3a5570" }}>{scene.chapter}</span>
-                </div>
-                <div style={{ fontSize: 12, color: "#8ab0cc", lineHeight: 1.4 }}>{scene.title ? scene.title : <span style={{ color: "#2a4060", fontStyle: "italic" }}>無題</span>}</div>
-                {manuscripts[scene.id] && <div style={{ fontSize: 10, color: "#2a4060", marginTop: 2 }}>{manuscripts[scene.id].replace(/\s/g, "").length}字</div>}
-              </div>
-            ))}
-            <div style={{ padding: "12px 16px" }}>
-              {!addingScene ? (
-                <button onClick={() => setAddingScene(true)} style={{ width: "100%", padding: "7px", border: "1px dashed #1e2d42", background: "transparent", color: "#2a4060", cursor: "pointer", fontSize: 11, borderRadius: 4, fontFamily: "inherit" }}>＋ シーンを追加</button>
-              ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                  {[["chapter", "章名"], ["title", "タイトル"], ["synopsis", "概要"]].map(([key, ph]) => (
-                    <input key={key} placeholder={ph} value={newScene[key as keyof SceneDraft]} onChange={e => setNewScene({ ...newScene, [key as keyof SceneDraft]: e.target.value })} style={{ background: "#0e1520", border: "1px solid #1e2d42", color: "#8ab0cc", padding: "5px 8px", borderRadius: 3, fontSize: 11, fontFamily: "inherit", outline: "none" }} />
-                  ))}
-                  <div style={{ display: "flex", gap: 4 }}>
-                    <button onClick={handleAddScene} style={{ flex: 1, padding: "5px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>追加</button>
-                    <button onClick={() => setAddingScene(false)} style={{ flex: 1, padding: "5px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>キャンセル</button>
-                  </div>
-                </div>
-              )}
-            </div>
-          </>}
 
-          {/* Sidebar content: 構成 = chapter tree */}
-          {sidebarTab === "structure" && (() => {
-            const chapters = scenes.reduce((acc, scene) => {
-              const ch = scene.chapter || "未分類";
-              if (!acc[ch]) acc[ch] = [];
-              acc[ch].push(scene);
-              return acc;
-            }, {} as Record<string, Scene[]>);
-            return (
-              <div style={{ padding: "10px 10px", display: "flex", flexDirection: "column", gap: 12 }}>
-                {Object.entries(chapters).map(([chapter, chScenes]) => {
-                  const allDone = chScenes.every(s => s.status === "done");
-                  const anyDraft = chScenes.some(s => s.status === "draft");
-                  const chColor = allDone ? statusColors.done : anyDraft ? statusColors.draft : statusColors.empty;
-                  const isAddingHere = addingScene && newScene.chapter === chapter;
-                  return (
-                    <div key={chapter}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4, paddingBottom: 4, borderBottom: "1px solid #1a2535" }}>
-                        <span style={{ width: 7, height: 7, borderRadius: "50%", flexShrink: 0, background: chColor, boxShadow: `0 0 5px ${chColor}66` }} />
-                        <span style={{ fontSize: 11, color: "#c8d8e8", fontWeight: 600, flex: 1 }}>{chapter || "未分類"}</span>
-                        <button onClick={() => { setNewScene({ chapter, title: "", synopsis: "" }); setAddingScene(true); }} style={{ fontSize: 10, padding: "1px 6px", background: "transparent", border: "1px solid #1e2d42", color: "#2a4060", borderRadius: 3, cursor: "pointer", fontFamily: "inherit" }}>＋</button>
-                      </div>
-                      <div style={{ display: "flex", flexDirection: "column", gap: 3, paddingLeft: 10 }}>
-                        {chScenes.map(scene => (
-                          <div key={scene.id} onClick={() => handleSceneSelect(scene)} style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 8px", borderRadius: 4, cursor: "pointer", background: selectedSceneId === scene.id ? "rgba(74,111,165,0.1)" : "transparent", border: "1px solid", borderColor: selectedSceneId === scene.id ? "#4a6fa5" : "transparent" }}>
-                            <span style={{ width: 5, height: 5, borderRadius: "50%", flexShrink: 0, background: statusColors[scene.status] }} />
-                            <span style={{ fontSize: 11, color: "#8ab0cc", flex: 1 }}>{scene.title ? scene.title : <span style={{ color: "#2a4060", fontStyle: "italic" }}>無題</span>}</span>
-                          </div>
-                        ))}
-                        {isAddingHere && (
-                          <div style={{ padding: "6px 8px", background: "#0a0f1a", border: "1px dashed #2a4060", borderRadius: 4, display: "flex", flexDirection: "column", gap: 5 }}>
-                            <input autoFocus placeholder="タイトル" value={newScene.title} onChange={e => setNewScene({ ...newScene, title: e.target.value })} onKeyDown={e => e.key === "Enter" && handleAddScene()} style={{ background: "transparent", border: "none", borderBottom: "1px solid #2a4060", color: "#8ab0cc", fontSize: 11, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
-                            <div style={{ display: "flex", gap: 4 }}>
-                              <button onClick={handleAddScene} style={{ flex: 1, padding: "3px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>追加</button>
-                              <button onClick={() => setAddingScene(false)} style={{ flex: 1, padding: "3px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>×</button>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-                {addingChapter ? (
-                  <div style={{ background: "#0a0f1a", border: "1px dashed #2a4060", borderRadius: 5, padding: "8px 10px", display: "flex", flexDirection: "column", gap: 5 }}>
-                    <input autoFocus placeholder="章名" value={newScene.chapter} onChange={e => setNewScene({ ...newScene, chapter: e.target.value })} style={{ background: "transparent", border: "none", borderBottom: "1px solid #2a4060", color: "#c8d8e8", fontSize: 12, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
-                    <input placeholder="タイトル（省略可）" value={newScene.title} onChange={e => setNewScene({ ...newScene, title: e.target.value })} onKeyDown={e => { if (e.key === "Enter") { handleAddScene(); setAddingChapter(false); }}} style={{ background: "transparent", border: "none", borderBottom: "1px solid #1a2535", color: "#8ab0cc", fontSize: 11, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
-                    <div style={{ display: "flex", gap: 4 }}>
-                      <button onClick={() => { handleAddScene(); setAddingChapter(false); }} style={{ flex: 1, padding: "3px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>追加</button>
-                      <button onClick={() => { setAddingChapter(false); setNewScene({ chapter: "", title: "", synopsis: "" }); }} style={{ flex: 1, padding: "3px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>×</button>
-                    </div>
-                  </div>
-                ) : (
-                  <button onClick={() => { setNewScene({ chapter: "", title: "", synopsis: "" }); setAddingChapter(true); }} style={{ padding: "6px", border: "1px dashed #1e2d42", background: "transparent", color: "#2a4060", cursor: "pointer", fontSize: 10, borderRadius: 4, fontFamily: "inherit" }}>＋ 新しい章</button>
-                )}
+            {/* Sidebar content: 執筆 = scene list */}
+            {sidebarTab === "write" && <>
+              <div style={{ padding: "8px 12px 4px" }}>
+                <input
+                  placeholder="シーンを検索…"
+                  value={sceneSearch}
+                  onChange={e => setSceneSearch(e.target.value)}
+                  style={{ width: "100%", background: "#0e1520", border: "1px solid #1e2d42", color: "#8ab0cc", padding: "5px 8px", borderRadius: 4, fontSize: 11, fontFamily: "inherit", outline: "none", boxSizing: "border-box" }}
+                />
               </div>
-            );
-          })()}
-
-          {/* Sidebar content: 設定 */}
-          {sidebarTab === "settings" && (
-            <div style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 8 }}>
-              {[["world","世界観"],["characters","キャラクター"],["theme","テーマ"]].map(([key, label]) => (
-                <div key={key}>
-                  <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 4 }}>{label}</div>
-                  <textarea value={settings[key as keyof Settings]} onChange={e => setSettings({ ...settings, [key]: e.target.value })} style={{ width: "100%", minHeight: 80, background: "#070a14", border: "1px solid #1a2535", color: "#8ab0cc", fontFamily: "inherit", fontSize: 11, lineHeight: 1.8, padding: "6px 8px", resize: "vertical", outline: "none", borderRadius: 4, boxSizing: "border-box" }} />
+              <div style={{ padding: "4px 16px 4px", fontSize: 10, letterSpacing: 3, color: "#2a4060", textTransform: "uppercase" }}>Scene List</div>
+              {scenes.filter(s => !sceneSearch || (s.title || "無題").includes(sceneSearch) || (s.chapter || "").includes(sceneSearch)).map(scene => (
+                <div key={scene.id} onClick={() => handleSceneSelect(scene)} style={{ padding: "10px 16px", cursor: "pointer", borderLeft: selectedSceneId === scene.id ? "2px solid #4a6fa5" : "2px solid transparent", background: selectedSceneId === scene.id ? "rgba(74,111,165,0.08)" : "transparent", borderBottom: "1px solid #0e1520" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 3 }}>
+                    <span style={{ width: 7, height: 7, borderRadius: "50%", flexShrink: 0, background: statusColors[scene.status], boxShadow: `0 0 6px ${statusColors[scene.status]}66` }} />
+                    <span style={{ fontSize: 10, color: "#3a5570" }}>{scene.chapter}</span>
+                  </div>
+                  <div style={{ fontSize: 12, color: "#8ab0cc", lineHeight: 1.4 }}>{scene.title ? scene.title : <span style={{ color: "#2a4060", fontStyle: "italic" }}>無題</span>}</div>
+                  {manuscripts[scene.id] && <div style={{ fontSize: 10, color: "#2a4060", marginTop: 2 }}>{manuscripts[scene.id].replace(/\s/g, "").length}字</div>}
                 </div>
               ))}
-            </div>
-          )}
-          {sidebarTab === "prefs" && (
-            <div style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 12 }}>
-              <div>
-                <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>文字サイズ　<span style={{ color: "#8ab0cc" }}>{editorSettings.fontSize}px</span></div>
-                <input type="range" min={12} max={24} value={editorSettings.fontSize} onChange={e => setEditorSettings(s => ({ ...s, fontSize: Number(e.target.value) }))} style={{ width: "100%" }} />
+              <div style={{ padding: "12px 16px" }}>
+                {!addingScene ? (
+                  <button onClick={() => setAddingScene(true)} style={{ width: "100%", padding: "7px", border: "1px dashed #1e2d42", background: "transparent", color: "#2a4060", cursor: "pointer", fontSize: 11, borderRadius: 4, fontFamily: "inherit" }}>＋ シーンを追加</button>
+                ) : (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                    {[["chapter", "章名"], ["title", "タイトル"], ["synopsis", "概要"]].map(([key, ph]) => (
+                      <input key={key} placeholder={ph} value={newScene[key as keyof SceneDraft]} onChange={e => setNewScene({ ...newScene, [key as keyof SceneDraft]: e.target.value })} style={{ background: "#0e1520", border: "1px solid #1e2d42", color: "#8ab0cc", padding: "5px 8px", borderRadius: 3, fontSize: 11, fontFamily: "inherit", outline: "none" }} />
+                    ))}
+                    <div style={{ display: "flex", gap: 4 }}>
+                      <button onClick={handleAddScene} style={{ flex: 1, padding: "5px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>追加</button>
+                      <button onClick={() => setAddingScene(false)} style={{ flex: 1, padding: "5px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>キャンセル</button>
+                    </div>
+                  </div>
+                )}
               </div>
-              <div>
-                <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>行間　<span style={{ color: "#8ab0cc" }}>{editorSettings.lineHeight}</span></div>
-                <input type="range" min={1.4} max={3.0} step={0.1} value={editorSettings.lineHeight} onChange={e => setEditorSettings(s => ({ ...s, lineHeight: Number(e.target.value) }))} style={{ width: "100%" }} />
+            </>}
+
+            {/* Sidebar content: 構成 = chapter tree */}
+            {sidebarTab === "structure" && (() => {
+              const chapters = scenes.reduce((acc, scene) => {
+                const ch = scene.chapter || "未分類";
+                if (!acc[ch]) acc[ch] = [];
+                acc[ch].push(scene);
+                return acc;
+              }, {} as Record<string, Scene[]>);
+              return (
+                <div style={{ padding: "10px 10px", display: "flex", flexDirection: "column", gap: 12 }}>
+                  {Object.entries(chapters).map(([chapter, chScenes]) => {
+                    const allDone = chScenes.every(s => s.status === "done");
+                    const anyDraft = chScenes.some(s => s.status === "draft");
+                    const chColor = allDone ? statusColors.done : anyDraft ? statusColors.draft : statusColors.empty;
+                    const isAddingHere = addingScene && newScene.chapter === chapter;
+                    return (
+                      <div key={chapter}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4, paddingBottom: 4, borderBottom: "1px solid #1a2535" }}>
+                          <span style={{ width: 7, height: 7, borderRadius: "50%", flexShrink: 0, background: chColor, boxShadow: `0 0 5px ${chColor}66` }} />
+                          <span style={{ fontSize: 11, color: "#c8d8e8", fontWeight: 600, flex: 1 }}>{chapter || "未分類"}</span>
+                          <button onClick={() => { setNewScene({ chapter, title: "", synopsis: "" }); setAddingScene(true); }} style={{ fontSize: 10, padding: "1px 6px", background: "transparent", border: "1px solid #1e2d42", color: "#2a4060", borderRadius: 3, cursor: "pointer", fontFamily: "inherit" }}>＋</button>
+                        </div>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 3, paddingLeft: 10 }}>
+                          {chScenes.map(scene => (
+                            <div key={scene.id} onClick={() => handleSceneSelect(scene)} style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 8px", borderRadius: 4, cursor: "pointer", background: selectedSceneId === scene.id ? "rgba(74,111,165,0.1)" : "transparent", border: "1px solid", borderColor: selectedSceneId === scene.id ? "#4a6fa5" : "transparent" }}>
+                              <span style={{ width: 5, height: 5, borderRadius: "50%", flexShrink: 0, background: statusColors[scene.status] }} />
+                              <span style={{ fontSize: 11, color: "#8ab0cc", flex: 1 }}>{scene.title ? scene.title : <span style={{ color: "#2a4060", fontStyle: "italic" }}>無題</span>}</span>
+                            </div>
+                          ))}
+                          {isAddingHere && (
+                            <div style={{ padding: "6px 8px", background: "#0a0f1a", border: "1px dashed #2a4060", borderRadius: 4, display: "flex", flexDirection: "column", gap: 5 }}>
+                              <input autoFocus placeholder="タイトル" value={newScene.title} onChange={e => setNewScene({ ...newScene, title: e.target.value })} onKeyDown={e => e.key === "Enter" && handleAddScene()} style={{ background: "transparent", border: "none", borderBottom: "1px solid #2a4060", color: "#8ab0cc", fontSize: 11, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
+                              <div style={{ display: "flex", gap: 4 }}>
+                                <button onClick={handleAddScene} style={{ flex: 1, padding: "3px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>追加</button>
+                                <button onClick={() => setAddingScene(false)} style={{ flex: 1, padding: "3px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>×</button>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {addingChapter ? (
+                    <div style={{ background: "#0a0f1a", border: "1px dashed #2a4060", borderRadius: 5, padding: "8px 10px", display: "flex", flexDirection: "column", gap: 5 }}>
+                      <input autoFocus placeholder="章名" value={newScene.chapter} onChange={e => setNewScene({ ...newScene, chapter: e.target.value })} style={{ background: "transparent", border: "none", borderBottom: "1px solid #2a4060", color: "#c8d8e8", fontSize: 12, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
+                      <input placeholder="タイトル（省略可）" value={newScene.title} onChange={e => setNewScene({ ...newScene, title: e.target.value })} onKeyDown={e => { if (e.key === "Enter") { handleAddScene(); setAddingChapter(false); }}} style={{ background: "transparent", border: "none", borderBottom: "1px solid #1a2535", color: "#8ab0cc", fontSize: 11, fontFamily: "inherit", outline: "none", padding: "2px 0" }} />
+                      <div style={{ display: "flex", gap: 4 }}>
+                        <button onClick={() => { handleAddScene(); setAddingChapter(false); }} style={{ flex: 1, padding: "3px", background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>追加</button>
+                        <button onClick={() => { setAddingChapter(false); setNewScene({ chapter: "", title: "", synopsis: "" }); }} style={{ flex: 1, padding: "3px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 3, fontSize: 10, fontFamily: "inherit" }}>×</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button onClick={() => { setNewScene({ chapter: "", title: "", synopsis: "" }); setAddingChapter(true); }} style={{ padding: "6px", border: "1px dashed #1e2d42", background: "transparent", color: "#2a4060", cursor: "pointer", fontSize: 10, borderRadius: 4, fontFamily: "inherit" }}>＋ 新しい章</button>
+                  )}
+                </div>
+              );
+            })()}
+
+            {/* Sidebar content: 設定 */}
+            {sidebarTab === "settings" && (
+              <div style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 8 }}>
+                {[["world","世界観"],["characters","キャラクター"],["theme","テーマ"]].map(([key, label]) => (
+                  <div key={key}>
+                    <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 4 }}>{label}</div>
+                    <textarea value={settings[key as keyof Settings]} onChange={e => setSettings({ ...settings, [key]: e.target.value })} style={{ width: "100%", minHeight: 80, background: "#070a14", border: "1px solid #1a2535", color: "#8ab0cc", fontFamily: "inherit", fontSize: 11, lineHeight: 1.8, padding: "6px 8px", resize: "vertical", outline: "none", borderRadius: 4, boxSizing: "border-box" }} />
+                  </div>
+                ))}
               </div>
-            </div>
-          )}
+            )}
+            {sidebarTab === "prefs" && (
+              <div style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 12 }}>
+                <div>
+                  <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>文字サイズ　<span style={{ color: "#8ab0cc" }}>{editorSettings.fontSize}px</span></div>
+                  <input type="range" min={12} max={24} value={editorSettings.fontSize} onChange={e => setEditorSettings(s => ({ ...s, fontSize: Number(e.target.value) }))} style={{ width: "100%" }} />
+                </div>
+                <div>
+                  <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>行間　<span style={{ color: "#8ab0cc" }}>{editorSettings.lineHeight}</span></div>
+                  <input type="range" min={1.4} max={3.0} step={0.1} value={editorSettings.lineHeight} onChange={e => setEditorSettings(s => ({ ...s, lineHeight: Number(e.target.value) }))} style={{ width: "100%" }} />
+                </div>
+              </div>
+            )}
+          </div>
+          {renderAiHistory(false)}
         </>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 4 }}>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 4, height: "100%" }}>
           <button onClick={() => setSidebarOpen(true)} style={{ padding: "8px 0", width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>▶</button>
           {[
             { key: "write", label: "執筆" },
@@ -208,6 +264,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               background: tab === key ? "rgba(74,111,165,0.08)" : "transparent",
             }}>{label}</button>
           ))}
+          {renderAiHistory(true)}
         </div>
       )}
     </aside>

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,14 @@ export type AiResults = {
   worldExpand: string;
 };
 
+export type AiHistoryItem = {
+  id: string;
+  type: keyof AiResults;
+  label: string;
+  content: string;
+  timestamp: string;
+};
+
 export type AiErrors = Record<keyof AiResults, string>;
 export type AiLoading = Record<keyof AiResults, boolean>;
 


### PR DESCRIPTION
Track AI outputs and show them in the sidebar, persist history to storage, and display an export success toast. Introduces AiHistoryItem type and aiHistory state, adds addAiHistory helper to record AI results (keeps last 50). Sidebar renders compact/full history with clear and expand actions; AiAssistant now records polish/hint/check results. Adds a fadeOut animation and exportStatus toast in Studio, persists aiHistory to local storage, and includes BOM in download blobs for Windows compatibility. Files changed: index.html, src/types.ts, src/hooks/useStudioState.ts, src/components/ai/AiAssistant.tsx, src/components/layout/Sidebar.tsx, src/App.tsx.