### PR TITLE
YUY-7: バックアップ復元で世界観設定と作品タイトルも復元する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,9 +117,11 @@ function Studio({ user }: { user: User }) {
           _scenes={scenes}
           _settings={settings}
           _manuscripts={manuscripts}
-          onRestore={(sc, ms) => {
+          onRestore={(sc, ms, restoredSettings, restoredTitle) => {
             setScenes(sc);
             setManuscripts(ms);
+            if (restoredSettings) setSettings(restoredSettings);
+            if (restoredTitle) setProjectTitle(restoredTitle);
             setShowBackups(false);
           }}
           onSaveBackup={handleSaveBackup}

--- a/src/components/modals/BackupModal.tsx
+++ b/src/components/modals/BackupModal.tsx
@@ -7,7 +7,7 @@ type BackupModalProps = {
   _scenes: Scene[];
   _settings: Settings;
   _manuscripts: Manuscripts;
-  onRestore: (scenes: Scene[], manuscripts: Manuscripts) => void;
+  onRestore: (scenes: Scene[], manuscripts: Manuscripts, settings?: Settings, projectTitle?: string) => void;
   onSaveBackup: (label: string | null) => void;
   onClose: () => void;
 };
@@ -134,7 +134,7 @@ export function BackupModal({
                     </div>
                   </div>
                   <button
-                    onClick={() => onRestore(bk.scenes || [], bk.manuscripts || {})}
+                    onClick={() => onRestore(bk.scenes || [], bk.manuscripts || {}, bk.settings, bk.projectTitle)}
                     style={{
                       padding: "4px 12px",
                       background: "rgba(74,111,165,0.15)",

--- a/src/hooks/useStudioState.ts
+++ b/src/hooks/useStudioState.ts
@@ -214,7 +214,7 @@ export function useStudioState(_user: User) {
   const saveWithBackup = async (sc: Scene[], st: Settings, ms: Manuscripts, pt: string, label: string | null = null) => {
     setSaveStatus("saving");
     try {
-      const newBackup = { timestamp: new Date().toISOString(), label, scenes: sc, manuscripts: ms };
+      const newBackup = { timestamp: new Date().toISOString(), label, scenes: sc, manuscripts: ms, settings: st, projectTitle: pt };
       const updatedBackups = [newBackup, ...backups].slice(0, 5);
       setBackups(updatedBackups);
       
@@ -251,11 +251,11 @@ export function useStudioState(_user: User) {
     if (!loaded) return;
     const timer = setInterval(() => {
       const { scenes: sc, manuscripts: ms } = latestStateRef.current;
-      const newAutoBackup: Backup = { timestamp: new Date().toISOString(), label: null, scenes: sc, manuscripts: ms };
+      const newAutoBackup: Backup = { timestamp: new Date().toISOString(), label: null, scenes: sc, manuscripts: ms, settings, projectTitle };
       setAutoBackups(prev => [newAutoBackup, ...prev].slice(0, 5));
     }, 10 * 60 * 1000);
     return () => clearInterval(timer);
-  }, [loaded]);
+  }, [loaded, settings, projectTitle]);
 
   const handleSceneSelect = (scene: Scene) => { setSelectedSceneId(scene.id); setTab("write"); };
   const handleManuscriptChange = (text: string) => setManuscripts(prev => ({ ...prev, [selectedSceneId as number]: text }));
@@ -315,6 +315,8 @@ export function useStudioState(_user: User) {
       label,
       scenes,
       manuscripts,
+      settings,
+      projectTitle,
     };
     const updated = [newBackup, ...backups].slice(0, 5);
     setBackups(updated);

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export type Backup = {
   label: string | null;
   scenes: Scene[];
   manuscripts: Manuscripts;
+  settings: Settings;
+  projectTitle: string;
 };
 
 export type HintItem = { hint: string; reason: string; keyword?: string };


### PR DESCRIPTION
### Motivation
- バックアップがシーン本文のみを保持しており、プロジェクト全体（世界観タブの設定や作品タイトル）を復元できなかったため、復元時の再現性を高める。 

### Description
- `Backup` 型に `settings` と `projectTitle` を追加してバックアップ構造を拡張した。 
- バックアップ作成処理（保存時バックアップ・手動記録・自動バックアップ）に `settings` と `projectTitle` を含めるように `useStudioState` を更新した。 
- バックアップモーダルの `onRestore` シグネチャを拡張し、各バックアップ項目から `settings` と `projectTitle` を渡すように変更した。 
- `App` 側の復元処理を更新して、復元データに `settings` / `projectTitle` が含まれている場合はそれらを適用するようにした（既存データ互換のため optional 受け取り）。

### Testing
- `npm run test:run` を実行し、全テストが成功（6ファイル・51テストすべて通過）。
- `npm run build` を実行して型チェックとビルドを確認し、ビルド成功（PWA アセット生成含む）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12d47b2d0832386196dc2ab3a5013)