### PR TITLE
Add GitHub release workflow and initialize CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:run
+
+      - name: Build app
+        run: npm run build
+
+      - name: Package build artifact
+        run: |
+          cd dist
+          zip -r ../minato-writing-studio-${{ github.ref_name }}.zip .
+
+      - name: Generate release notes from CHANGELOG
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" {capture=1; next}
+            capture && $0 ~ "^## \\[" {capture=0}
+            capture {print}
+          ' CHANGELOG.md | sed '/^[[:space:]]*$/d' > RELEASE_NOTES.md
+
+          if [ ! -s RELEASE_NOTES.md ]; then
+            {
+              echo "Release ${GITHUB_REF_NAME}"
+              echo
+              echo "See CHANGELOG.md for details."
+            } > RELEASE_NOTES.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASE_NOTES.md
+          files: minato-writing-studio-${{ github.ref_name }}.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- release workflow (`.github/workflows/release.yml`) to automate test, build, packaging, and GitHub release publication.
+
+## [1.0.0] - 2026-02-27
+
+### Added
+- Initial release of Minato Writing Studio.


### PR DESCRIPTION
### Motivation
- Automate the release process for tagged versions so tests, build, packaging, and GitHub Release publication happen consistently.
- Provide a canonical changelog using the Keep a Changelog format so release notes can be generated from source-controlled text.

### Description
- Add `.github/workflows/release.yml` to run on `push` tags matching `v*` and `workflow_dispatch`, performing checkout, Node setup, `npm ci`, `npm run test:run`, `npm run build`, packaging `dist` into `minato-writing-studio-${{ github.ref_name }}.zip`, extracting release notes from `CHANGELOG.md` into `RELEASE_NOTES.md`, and creating a GitHub Release with the artifact via `softprops/action-gh-release@v2`.
- Add `CHANGELOG.md` using Keep a Changelog style with an `Unreleased` section and an initial `1.0.0` entry.
- Release notes extraction in the workflow matches `## [x.y.z]` sections in `CHANGELOG.md` and falls back to a short default note when no matching section is found.

### Testing
- Ran `npm run test:run` (Vitest) and all tests passed (51 tests across 6 test files).
- Ran `npm run build` and the production build completed successfully producing the `dist` output and service worker artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d67779848323a72e109f4fab4387)