### PR TITLE
fix: ヘッダーで空白タイトル時も編集可能にする

### DIFF
--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { Header } from "../components/layout/Header";
+
+vi.mock("../supabase", () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn(),
+    },
+  },
+}));
+
+describe("Header", () => {
+  test("shows placeholder and allows entering edit mode when project title is blank", () => {
+    const setEditingTitle = vi.fn();
+
+    render(
+      <Header
+        projectTitle="   "
+        setProjectTitle={vi.fn()}
+        editingTitle={false}
+        setEditingTitle={setEditingTitle}
+        saveStatus="saved"
+        lastSavedTime={null}
+        scenes={[]}
+        settings={{ world: "", characters: "", theme: "" }}
+        manuscripts={{}}
+        saveWithBackup={vi.fn()}
+        setShowBackups={vi.fn()}
+        setShowExport={vi.fn()}
+      />,
+    );
+
+    const title = screen.getByText("タイトル未設定");
+    expect(title).toBeInTheDocument();
+
+    fireEvent.click(title);
+    expect(setEditingTitle).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,8 @@ export const Header: React.FC<HeaderProps> = ({
   saveStatus, lastSavedTime, scenes, settings, manuscripts,
   saveWithBackup, setShowBackups, setShowExport
 }) => {
+  const hasProjectTitle = projectTitle.trim().length > 0;
+
   return (
     <header style={{ borderBottom: "1px solid #1e2d42", padding: "0 16px", display: "flex", alignItems: "center", justifyContent: "space-between", background: "rgba(10,14,26,0.95)", position: "sticky", top: 0, zIndex: 100, height: 44 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
@@ -49,8 +51,23 @@ export const Header: React.FC<HeaderProps> = ({
             style={{ background: "transparent", border: "none", borderBottom: "1px solid #4a6fa5", color: "#e2eaf4", fontSize: 15, fontWeight: 700, fontFamily: "'Noto Serif JP','Georgia',serif", outline: "none", letterSpacing: 1, width: 280 }}
           />
         ) : (
-          <div onClick={() => setEditingTitle(true)} style={{ fontSize: 15, fontWeight: 700, color: "#c8d8e8", letterSpacing: 1, cursor: "text", fontFamily: "'Noto Serif JP','Georgia',serif" }} title="クリックで編集">
-            {projectTitle}
+          <div
+            onClick={() => setEditingTitle(true)}
+            style={{
+              fontSize: 15,
+              fontWeight: 700,
+              color: hasProjectTitle ? "#c8d8e8" : "#3a5570",
+              letterSpacing: 1,
+              cursor: "text",
+              fontFamily: "'Noto Serif JP','Georgia',serif",
+              minWidth: 120,
+              minHeight: 22,
+              display: "flex",
+              alignItems: "center",
+            }}
+            title="クリックで編集"
+          >
+            {hasProjectTitle ? projectTitle : <span style={{ fontStyle: "italic" }}>タイトル未設定</span>}
           </div>
         )}
       </div>


### PR DESCRIPTION
### Motivation
- ヘッダーのプロジェクトタイトルが空白（空白文字のみ）だと見た目上クリックや編集がわかりにくく、編集に入れない不具合を解消するため。

### Description
- `Header` コンポーネントで `projectTitle.trim().length > 0` を判定する `hasProjectTitle` を導入して表示分岐を追加した。 
- 空白時はプレースホルダーとして `タイトル未設定` をイタリックで表示し、常にクリックできるよう `minWidth`/`minHeight` と表示領域のスタイルを付与した。 
- 空白タイトル時の表示・クリック挙動を検証する `src/__tests__/Header.test.tsx` を追加した。

### Testing
- `npm test -- --run src/__tests__/Header.test.tsx` を実行し該当テストが成功しました（1 passed）。
- `npm test -- --run` を実行しプロジェクトのテストスイートが全て成功しました（52 tests passed）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d8bab32c83239fcc5257de3668b2)