### PR TITLE
fix: 起動画面の表示名を minato Writing Studio に統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,10 @@ export default function App() {
   }, []);
 
   if (authLoading) return (
-    <div style={{ height: "100dvh", display: "flex", alignItems: "center", justifyContent: "center", background: "#0a0e1a", color: "#2a4060", fontSize: 12, letterSpacing: 2 }}>読み込み中…</div>
+    <div style={{ height: "100dvh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", background: "#0a0e1a", gap: 8 }}>
+      <div style={{ color: "#2a4060", fontSize: 12, letterSpacing: 2 }}>読み込み中…</div>
+      <div style={{ color: "#1e3050", fontSize: 11, letterSpacing: 1 }}>minato Writing Studio</div>
+    </div>
   );
 
   if (!user) return (
@@ -49,7 +52,7 @@ export default function App() {
         </svg>
         <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textAlign: "center", marginTop: 4 }}>minato ws</div>
       </div>
-      <div style={{ fontSize: 18, color: "#c8d8e8", fontWeight: 700, fontFamily: "'Noto Serif JP','Georgia',serif", letterSpacing: 1 }}>港に届いた例外</div>
+      <div style={{ fontSize: 18, color: "#c8d8e8", fontWeight: 700, fontFamily: "'Noto Serif JP','Georgia',serif", letterSpacing: 1 }}>minato Writing Studio</div>
       <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{
         padding: "10px 28px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5",
         color: "#7ab3e0", cursor: "pointer", borderRadius: 6, fontSize: 13, fontFamily: "inherit", letterSpacing: 1,
@@ -84,8 +87,9 @@ function Studio({ user }: { user: User }) {
   } = useStudioState(user);
 
   if (!loaded) return (
-    <div style={{ minHeight: "100vh", background: "#0a0e1a", display: "flex", alignItems: "center", justifyContent: "center" }}>
+    <div style={{ minHeight: "100vh", background: "#0a0e1a", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 8 }}>
       <div style={{ color: "#2a4060", fontSize: 12, letterSpacing: 3 }}>loading...</div>
+      <div style={{ color: "#1e3050", fontSize: 11, letterSpacing: 1 }}>minato Writing Studio</div>
     </div>
   );
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -25,7 +25,7 @@ vi.mock("../supabase", () => ({
 describe("App", () => {
   test("renders project title when not authenticated", async () => {
     render(<App />);
-    const titleElement = await screen.findByText(/港に届いた例外/i);
+    const titleElement = await screen.findByText(/minato Writing Studio/i);
     expect(titleElement).toBeInTheDocument();
   });
 


### PR DESCRIPTION
### Motivation
- 起動画面（未ログイン時）のメインタイトルが個別の文言になっており、アプリ名で起動したい要望に沿って表示名を統一するための変更です。 
- 認証読み込み中やStudioの初期読み込み中にもアプリ名を表示して、起動導線の表示を一貫させる目的です。

### Description
- `src/App.tsx` の未認証表示のタイトルを `港に届いた例外` から `minato Writing Studio` に変更しました。 
- 認証読み込み中（`authLoading`）と Studio の初期読み込み中（`loaded` が false）の画面に `minato Writing Studio` 表示を追加し、レイアウトに `flexDirection` と `gap` を導入して見た目を整えました。 
- テスト期待値を更新するために `src/__tests__/App.test.tsx` のタイトル照合を `minato Writing Studio` に合わせて修正しました。 

### Testing
- `npm test -- --run src/__tests__/App.test.tsx` を実行して該当テストは成功しました。 
- プロジェクト全体で `npm test -- --run` を実行し、すべてのテスト（52 tests）が成功しました. 
- 変更ファイルは `src/App.tsx` と `src/__tests__/App.test.tsx` です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31884fab48323b2520fe65a38d2f5)