### PR TITLE
Fix: Record each polish suggestion as separate AI history entries

### DIFF
--- a/src/__tests__/AiAssistant.test.ts
+++ b/src/__tests__/AiAssistant.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { parsePolishHistoryEntries } from "../components/ai/AiAssistant";
+
+describe("parsePolishHistoryEntries", () => {
+  test("returns one history entry per suggestion", () => {
+    const input = JSON.stringify([
+      { reason: "語尾が重複", original: "彼は歩いた。", suggestion: "彼は静かに歩いた。" },
+      { reason: "描写不足", original: "空は青い。", suggestion: "空は群青に染まっていた。" },
+      { reason: "テンポ調整", original: "そして。", suggestion: "そして、彼は振り返った。" },
+    ]);
+
+    const entries = parsePolishHistoryEntries(input);
+
+    expect(entries).toEqual([
+      "・[語尾が重複] 彼は歩いた。 → 彼は静かに歩いた。",
+      "・[描写不足] 空は青い。 → 空は群青に染まっていた。",
+      "・[テンポ調整] そして。 → そして、彼は振り返った。",
+    ]);
+  });
+
+  test("ignores invalid suggestion entries", () => {
+    const input = JSON.stringify([
+      { reason: "ok", original: "a", suggestion: "b" },
+      { reason: "invalid", original: "", suggestion: "x" },
+      { reason: "invalid", original: "y" },
+    ]);
+
+    expect(parsePolishHistoryEntries(input)).toEqual(["・[ok] a → b"]);
+  });
+});

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -8,6 +8,19 @@ import type {
   AiResults, AiLoading, AiErrors
 } from "../../types";
 
+
+export function parsePolishHistoryEntries(result: string): string[] {
+  const clean = result.replace(/```json|```/g, "").trim();
+  const suggestions = JSON.parse(clean);
+  if (!Array.isArray(suggestions)) return [];
+
+  return suggestions
+    .filter((s): s is { reason?: string; original: string; suggestion: string } =>
+      typeof s?.original === "string" && s.original.trim().length > 0 && typeof s?.suggestion === "string" && s.suggestion.trim().length > 0
+    )
+    .map(s => `・[${s.reason ?? "理由なし"}] ${s.original} → ${s.suggestion}`);
+}
+
 interface AiAssistantProps {
   showSettings: boolean;
   setShowSettings: (v: boolean) => void;
@@ -162,10 +175,8 @@ export const AiAssistant: React.FC<AiAssistantProps> = ({
                   setAiResults(r => ({ ...r, polish: t }));
                   if (t) {
                     try {
-                      const clean = t.replace(/```json|```/g, "").trim();
-                      const suggestions = JSON.parse(clean);
-                      const historyText = suggestions.map((s: any) => `・[${s.reason}] ${s.original} → ${s.suggestion}`).join("\n");
-                      addAiHistory("推敲提案", historyText, selectedScene.title);
+                      const entries = parsePolishHistoryEntries(t);
+                      entries.forEach(entry => addAiHistory("推敲提案", entry, selectedScene.title));
                     } catch(e) {}
                   }
                 }}


### PR DESCRIPTION
### Motivation
- The polish feature produced a single concatenated history entry for multiple suggestions, making individual suggestions hard to track and revert. 
- The change fixes Linear issue YUY-11 by ensuring each AI suggestion is stored as its own history item. 

### Description
- Added `parsePolishHistoryEntries(result: string): string[]` to `src/components/ai/AiAssistant.tsx` to parse the AI JSON array and produce one history line per valid suggestion. 
- Updated the polish `onResult` handler in `AiAssistant` to call the parser and invoke `addAiHistory` once per parsed entry instead of concatenating all suggestions. 
- Implemented validation to ignore invalid/empty suggestion objects from the AI response. 
- Added unit tests `src/__tests__/AiAssistant.test.ts` to verify parsing behavior for multiple suggestions and invalid entries. 

### Testing
- Ran unit tests with `npm test -- --run` and all tests passed (8 test files, 54 tests). 
- Verified production build with `npm run build` completed successfully. 
- The new parser tests (`src/__tests__/AiAssistant.test.ts`) passed as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3188507d0832380818755cfcd0c6e)