### PR TITLE
Move studio state to StudioContext provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,11 @@ import { WriteView } from "./components/views/WriteView";
 import { StructureView } from "./components/views/StructureView";
 import { SettingsView } from "./components/views/SettingsView";
 import { PrefsView } from "./components/views/PrefsView";
-import { useStudioState } from "./hooks/useStudioState";
 import { BackupModal } from "./components/modals/BackupModal";
 import { ExportModal } from "./components/modals/ExportModal";
 import { DeleteConfirmModal } from "./components/modals/DeleteConfirmModal";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { StudioProvider, useStudio } from "./contexts/StudioContext";
 
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
@@ -62,29 +62,19 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <Studio user={user} />
+      <StudioProvider user={user}>
+        <Studio />
+      </StudioProvider>
     </ErrorBoundary>
   );
 }
 
-function Studio({ user }: { user: User }) {
+function Studio() {
   const {
-    loaded, saveStatus, lastSavedTime, tab, setTab, settings, setSettings,
-    settingsTab, setSettingsTab, scenes, setScenes, selectedSceneId,
-    manuscripts, setManuscripts, showSettings, setShowSettings, sidebarOpen, setSidebarOpen,
-    newScene, setNewScene, addingScene, setAddingScene, confirmDelete, setConfirmDelete,
-    addingChapter, setAddingChapter, projectTitle, setProjectTitle, editingTitle, setEditingTitle,
-    showExport, setShowExport, sceneSearch, setSceneSearch, backups,
-    showBackups, setShowBackups, verticalPreview, setVerticalPreview,
-    editingSceneTitle, setEditingSceneTitle, editingSceneSynopsis, setEditingSceneSynopsis,
-    sidebarFloat, setSidebarFloat, sidebarTab, setSidebarTab, editorSettings, setEditorSettings,
-    aiFloat, setAiFloat, aiWide, setAiWide, aiResults, setAiResults, aiErrors, setAiErrors, aiLoading, setAiLoading,
-    aiApplied, setAiApplied, hintApplied, setHintApplied,
-    selectedScene, manuscriptText, wordCount,
-    handleSceneSelect, handleManuscriptChange, handleStatusChange, handleAddScene,
-    handleDeleteScene, confirmDeleteExecute, saveWithBackup, exportScene, exportAll,
-    handleSaveBackup, aiHistory, addAiHistory, clearAiHistory, autoBackups,
-  } = useStudioState(user);
+    loaded, tab, sidebarOpen, showSettings,
+    confirmDelete, showExport, showBackups, setSidebarOpen, setShowSettings,
+    sidebarFloat, aiHistory, clearAiHistory, manuscriptText, handleManuscriptChange
+  } = useStudio();
 
   if (!loaded) return (
     <div style={{ minHeight: "100vh", background: "#0a0e1a", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 8 }}>
@@ -96,161 +86,25 @@ function Studio({ user }: { user: User }) {
   return (
     <div style={{ minHeight: "100vh", background: "#0a0e1a", color: "#c8d8e8", fontFamily: "'Noto Serif JP','Georgia',serif", display: "flex", flexDirection: "column" }}>
       {/* Delete confirm modal */}
-      {confirmDelete && (
-        <DeleteConfirmModal
-          scene={scenes.find((s) => s.id === confirmDelete)}
-          onConfirm={confirmDeleteExecute}
-          onCancel={() => setConfirmDelete(null)}
-        />
-      )}
+      {confirmDelete && <DeleteConfirmModal />}
       {/* Export modal */}
-      {showExport && (
-        <ExportModal
-          selectedScene={selectedScene}
-          _projectTitle={projectTitle}
-          onExportScene={exportScene}
-          onExportAll={exportAll}
-          onClose={() => setShowExport(false)}
-        />
-      )}
+      {showExport && <ExportModal />}
       {/* Backup modal */}
-      {showBackups && (
-        <BackupModal
-          backups={backups}
-          autoBackups={autoBackups}
-          _scenes={scenes}
-          _settings={settings}
-          _manuscripts={manuscripts}
-          onRestore={(sc, ms, restoredSettings, restoredTitle) => {
-            setScenes(sc);
-            setManuscripts(ms);
-            if (restoredSettings) setSettings(restoredSettings);
-            if (restoredTitle) setProjectTitle(restoredTitle);
-            setShowBackups(false);
-          }}
-          onSaveBackup={handleSaveBackup}
-          onClose={() => setShowBackups(false)}
-        />
-      )}
-      <Header
-        projectTitle={projectTitle}
-        setProjectTitle={setProjectTitle}
-        editingTitle={editingTitle}
-        setEditingTitle={setEditingTitle}
-        saveStatus={saveStatus}
-        lastSavedTime={lastSavedTime}
-        scenes={scenes}
-        settings={settings}
-        manuscripts={manuscripts}
-        saveWithBackup={saveWithBackup}
-        setShowBackups={setShowBackups}
-        setShowExport={setShowExport}
-      />
+      {showBackups && <BackupModal />}
+      <Header />
 
       <div style={{ display: "flex", flex: 1, minHeight: 0, position: "relative" }}>
         {/* フロートオーバーレイ背景 */}
-        {((sidebarOpen && sidebarFloat) || (showSettings && aiFloat && tab === "write")) && (
+        {((sidebarOpen && sidebarFloat) || (showSettings && tab === "write")) && (
           <div onClick={() => { setSidebarOpen(false); setShowSettings(false); }} style={{ position: "absolute", inset: 0, zIndex: 50, background: "rgba(0,0,0,0.4)" }} />
         )}
-        <Sidebar
-          sidebarOpen={sidebarOpen}
-          setSidebarOpen={setSidebarOpen}
-          sidebarFloat={sidebarFloat}
-          setSidebarFloat={setSidebarFloat}
-          sidebarTab={sidebarTab}
-          setSidebarTab={setSidebarTab}
-          tab={tab}
-          setTab={setTab}
-          scenes={scenes}
-          selectedSceneId={selectedSceneId}
-          manuscripts={manuscripts}
-          sceneSearch={sceneSearch}
-          setSceneSearch={setSceneSearch}
-          newScene={newScene}
-          setNewScene={setNewScene}
-          addingScene={addingScene}
-          setAddingScene={setAddingScene}
-          addingChapter={addingChapter}
-          setAddingChapter={setAddingChapter}
-          settings={settings}
-          setSettings={setSettings}
-          editorSettings={editorSettings}
-          setEditorSettings={setEditorSettings}
-          handleSceneSelect={handleSceneSelect}
-          handleAddScene={handleAddScene}
-          aiHistory={aiHistory}
-          onInsertHistory={(content) => handleManuscriptChange(manuscriptText + (manuscriptText ? "\n" : "") + content)}
-          onClearHistory={clearAiHistory}
-        />
+        <Sidebar />
 
         <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-          {tab === "write" && (
-            <WriteView
-              selectedScene={selectedScene}
-              scenes={scenes}
-              setScenes={setScenes}
-              selectedSceneId={selectedSceneId}
-              editingSceneTitle={editingSceneTitle}
-              setEditingSceneTitle={setEditingSceneTitle}
-              editingSceneSynopsis={editingSceneSynopsis}
-              setEditingSceneSynopsis={setEditingSceneSynopsis}
-              handleStatusChange={handleStatusChange}
-              verticalPreview={verticalPreview}
-              setVerticalPreview={setVerticalPreview}
-              handleDeleteScene={handleDeleteScene}
-              manuscriptText={manuscriptText}
-              handleManuscriptChange={handleManuscriptChange}
-              editorSettings={editorSettings}
-              handleSceneSelect={handleSceneSelect}
-              wordCount={wordCount}
-              aiResults={aiResults}
-              setAiResults={setAiResults}
-              aiErrors={aiErrors}
-              setAiErrors={setAiErrors}
-              aiLoading={aiLoading}
-              setAiLoading={setAiLoading}
-              settings={settings}
-              addAiHistory={addAiHistory}
-            />
-          )}
-
-          {tab === "structure" && (
-            <StructureView
-              scenes={scenes}
-              setScenes={setScenes}
-              manuscripts={manuscripts}
-              addingScene={addingScene}
-              setAddingScene={setAddingScene}
-              newScene={newScene}
-              setNewScene={setNewScene}
-              handleAddScene={handleAddScene}
-              addingChapter={addingChapter}
-              setAddingChapter={setAddingChapter}
-              handleSceneSelect={handleSceneSelect}
-              selectedSceneId={selectedSceneId}
-            />
-          )}
-
-          {tab === "settings" && (
-            <SettingsView
-              settings={settings}
-              setSettings={setSettings}
-              settingsTab={settingsTab}
-              setSettingsTab={setSettingsTab}
-              aiResults={aiResults}
-              setAiResults={setAiResults}
-              aiErrors={aiErrors}
-              setAiErrors={setAiErrors}
-              aiLoading={aiLoading}
-              setAiLoading={setAiLoading}
-            />
-          )}
-          {tab === "prefs" && (
-            <PrefsView
-              editorSettings={editorSettings}
-              setEditorSettings={setEditorSettings}
-            />
-          )}
+          {tab === "write" && <WriteView />}
+          {tab === "structure" && <StructureView />}
+          {tab === "settings" && <SettingsView />}
+          {tab === "prefs" && <PrefsView />}
           {tab === "ai" && (
             <div style={{ padding: "40px", maxWidth: "800px", margin: "0 auto", width: "100%", boxSizing: "border-box", overflowY: "auto" }}>
               <div style={{ display: "flex", alignItems: "center", marginBottom: "24px", borderBottom: "1px solid #1e2d42", paddingBottom: "12px" }}>
@@ -298,29 +152,7 @@ function Studio({ user }: { user: User }) {
         {/* AI Assistant */}
         {tab === "write" && (
           <ErrorBoundary fallback={<div style={{ position: "fixed", right: 16, bottom: 16, padding: "8px 16px", background: "#0a0e1a", border: "1px solid #2a4060", color: "#e05555", fontSize: 11, borderRadius: 4 }}>AIアシスタントでエラーが発生しました</div>}>
-            <AiAssistant
-              showSettings={showSettings}
-              setShowSettings={setShowSettings}
-              aiFloat={aiFloat}
-              setAiFloat={setAiFloat}
-              aiWide={aiWide}
-              setAiWide={setAiWide}
-              aiResults={aiResults}
-              setAiResults={setAiResults}
-              aiErrors={aiErrors}
-              setAiErrors={setAiErrors}
-              aiLoading={aiLoading}
-              setAiLoading={setAiLoading}
-              aiApplied={aiApplied}
-              setAiApplied={setAiApplied}
-              hintApplied={hintApplied}
-              setHintApplied={setHintApplied}
-              manuscriptText={manuscriptText}
-              handleManuscriptChange={handleManuscriptChange}
-              settings={settings}
-              selectedScene={selectedScene}
-              addAiHistory={addAiHistory}
-            />
+            <AiAssistant />
           </ErrorBoundary>
         )}
       </div>

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import "@testing-library/jest-dom";
 import { Header } from "../components/layout/Header";
+import { useStudio } from "../contexts/StudioContext";
 
 vi.mock("../supabase", () => ({
   supabase: {
@@ -11,26 +12,29 @@ vi.mock("../supabase", () => ({
   },
 }));
 
+vi.mock("../contexts/StudioContext", () => ({
+  useStudio: vi.fn(),
+}));
+
 describe("Header", () => {
   test("shows placeholder and allows entering edit mode when project title is blank", () => {
     const setEditingTitle = vi.fn();
+    (useStudio as any).mockReturnValue({
+      projectTitle: "   ",
+      setProjectTitle: vi.fn(),
+      editingTitle: false,
+      setEditingTitle: setEditingTitle,
+      saveStatus: "saved",
+      lastSavedTime: null,
+      scenes: [],
+      settings: { world: "", characters: "", theme: "" },
+      manuscripts: {},
+      saveWithBackup: vi.fn(),
+      setShowBackups: vi.fn(),
+      setShowExport: vi.fn(),
+    });
 
-    render(
-      <Header
-        projectTitle="   "
-        setProjectTitle={vi.fn()}
-        editingTitle={false}
-        setEditingTitle={setEditingTitle}
-        saveStatus="saved"
-        lastSavedTime={null}
-        scenes={[]}
-        settings={{ world: "", characters: "", theme: "" }}
-        manuscripts={{}}
-        saveWithBackup={vi.fn()}
-        setShowBackups={vi.fn()}
-        setShowExport={vi.fn()}
-      />,
-    );
+    render(<Header />);
 
     const title = screen.getByText("タイトル未設定");
     expect(title).toBeInTheDocument();

--- a/src/__tests__/StudioContext.test.tsx
+++ b/src/__tests__/StudioContext.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { User } from "@supabase/supabase-js";
@@ -17,19 +18,23 @@ vi.mock("../supabase", () => ({
   },
 }));
 
-import { useStudioState } from "../hooks/useStudioState";
+import { StudioProvider, useStudio } from "../contexts/StudioContext";
 import { initialScenes } from "../constants";
 
 const mockUser = { id: "user-1" } as User;
 
-describe("useStudioState", () => {
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <StudioProvider user={mockUser}>{children}</StudioProvider>
+);
+
+describe("StudioContext", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
   });
 
   it("initializes with default scenes", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
 
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
@@ -37,7 +42,7 @@ describe("useStudioState", () => {
   });
 
   it("starts with no selected scene", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
 
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
@@ -47,7 +52,7 @@ describe("useStudioState", () => {
   });
 
   it("selects a scene and updates selectedScene", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {
@@ -59,7 +64,7 @@ describe("useStudioState", () => {
   });
 
   it("updates manuscript text and computes wordCount", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {
@@ -75,7 +80,7 @@ describe("useStudioState", () => {
   });
 
   it("adds a new scene", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     const initialCount = result.current.scenes.length;
@@ -95,7 +100,7 @@ describe("useStudioState", () => {
   });
 
   it("deletes a scene via confirmDeleteExecute", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     const initialCount = result.current.scenes.length;
@@ -116,7 +121,7 @@ describe("useStudioState", () => {
   });
 
   it("deselects scene when selected scene is deleted", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {
@@ -135,7 +140,7 @@ describe("useStudioState", () => {
   });
 
   it("changes scene status", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {
@@ -147,13 +152,13 @@ describe("useStudioState", () => {
   });
 
   it("starts with default tab 'write'", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(result.current.tab).toBe("write");
   });
 
   it("updates project title", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {
@@ -164,7 +169,7 @@ describe("useStudioState", () => {
   });
 
   it("wordCount ignores whitespace", async () => {
-    const { result } = renderHook(() => useStudioState(mockUser));
+    const { result } = renderHook(() => useStudio(), { wrapper });
     await waitFor(() => expect(result.current.loaded).toBe(true));
 
     act(() => {

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -3,11 +3,7 @@ import { AiPanel } from "./AiPanel";
 import { HintPanel } from "./HintPanel";
 import { PolishPanel } from "./PolishPanel";
 import { callAnthropic, AiError } from "../../utils/ai";
-import type {
-  Scene, Settings, AppliedState,
-  AiResults, AiLoading, AiErrors
-} from "../../types";
-
+import { useStudio } from "../../contexts/StudioContext";
 
 export function parsePolishHistoryEntries(result: string): string[] {
   const clean = result.replace(/```json|```/g, "").trim();
@@ -21,38 +17,15 @@ export function parsePolishHistoryEntries(result: string): string[] {
     .map(s => `・[${s.reason ?? "理由なし"}] ${s.original} → ${s.suggestion}`);
 }
 
-interface AiAssistantProps {
-  showSettings: boolean;
-  setShowSettings: (v: boolean) => void;
-  aiFloat: boolean;
-  setAiFloat: (v: boolean) => void;
-  aiWide: boolean;
-  setAiWide: (v: boolean) => void;
-  aiResults: AiResults;
-  setAiResults: React.Dispatch<React.SetStateAction<AiResults>>;
-  aiErrors: AiErrors;
-  setAiErrors: React.Dispatch<React.SetStateAction<AiErrors>>;
-  aiLoading: AiLoading;
-  setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
-  aiApplied: AppliedState;
-  setAiApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
-  hintApplied: AppliedState;
-  setHintApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
-  manuscriptText: string;
-  handleManuscriptChange: (text: string) => void;
-  settings: Settings;
-  selectedScene: Scene | null;
-  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
-}
-
-export const AiAssistant: React.FC<AiAssistantProps> = ({
-  showSettings, setShowSettings, aiFloat, setAiFloat,
-  aiWide, setAiWide, aiResults, setAiResults,
-  aiErrors, setAiErrors,
-  aiLoading, setAiLoading, aiApplied, setAiApplied,
-  hintApplied, setHintApplied, manuscriptText,
-  handleManuscriptChange, settings, selectedScene, addAiHistory
-}) => {
+export const AiAssistant: React.FC = () => {
+  const {
+    showSettings, setShowSettings, aiFloat, setAiFloat,
+    aiWide, setAiWide, aiResults, setAiResults,
+    aiErrors, setAiErrors,
+    aiLoading, setAiLoading, aiApplied, setAiApplied,
+    hintApplied, setHintApplied, manuscriptText,
+    handleManuscriptChange, settings, selectedScene, addAiHistory
+  } = useStudio();
   const [freeText, setFreeText] = useState("");
 
   const runFreeInstruct = async () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,27 +1,13 @@
 import React from "react";
 import { supabase } from "../../supabase";
-import type { Scene, Settings, Manuscripts, SaveStatus } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-interface HeaderProps {
-  projectTitle: string;
-  setProjectTitle: (v: string) => void;
-  editingTitle: boolean;
-  setEditingTitle: (v: boolean) => void;
-  saveStatus: SaveStatus;
-  lastSavedTime: Date | null;
-  scenes: Scene[];
-  settings: Settings;
-  manuscripts: Manuscripts;
-  saveWithBackup: (sc: Scene[], st: Settings, ms: Manuscripts, pt: string) => void;
-  setShowBackups: (v: boolean) => void;
-  setShowExport: (v: boolean) => void;
-}
-
-export const Header: React.FC<HeaderProps> = ({
-  projectTitle, setProjectTitle, editingTitle, setEditingTitle,
-  saveStatus, lastSavedTime, scenes, settings, manuscripts,
-  saveWithBackup, setShowBackups, setShowExport
-}) => {
+export const Header: React.FC = () => {
+  const {
+    projectTitle, setProjectTitle, editingTitle, setEditingTitle,
+    saveStatus, lastSavedTime, scenes, settings, manuscripts,
+    saveWithBackup, setShowBackups, setShowExport
+  } = useStudio();
   const hasProjectTitle = projectTitle.trim().length > 0;
 
   return (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,53 +1,28 @@
 import React, { useState } from "react";
 import { statusColors } from "../../constants";
+import { useStudio } from "../../contexts/StudioContext";
 import type {
-  Scene, Manuscripts, SceneDraft, Settings, EditorSettings, SidebarTabKey, TabKey, AiHistoryItem
+  SceneDraft, Settings, SidebarTabKey, TabKey, Scene
 } from "../../types";
 
-interface SidebarProps {
-  sidebarOpen: boolean;
-  setSidebarOpen: (v: boolean) => void;
-  sidebarFloat: boolean;
-  setSidebarFloat: (v: boolean) => void;
-  sidebarTab: SidebarTabKey;
-  setSidebarTab: (v: SidebarTabKey) => void;
-  tab: TabKey;
-  setTab: (v: TabKey) => void;
-  scenes: Scene[];
-  selectedSceneId: number | null;
-  manuscripts: Manuscripts;
-  sceneSearch: string;
-  setSceneSearch: (v: string) => void;
-  newScene: SceneDraft;
-  setNewScene: (v: SceneDraft) => void;
-  addingScene: boolean;
-  setAddingScene: (v: boolean) => void;
-  addingChapter: boolean;
-  setAddingChapter: (v: boolean) => void;
-  settings: Settings;
-  setSettings: (v: Settings) => void;
-  editorSettings: EditorSettings;
-  setEditorSettings: React.Dispatch<React.SetStateAction<EditorSettings>>;
-  handleSceneSelect: (s: Scene) => void;
-  handleAddScene: () => void;
-  aiHistory: AiHistoryItem[];
-  onInsertHistory: (content: string) => void;
-  onClearHistory: () => void;
-}
-
-export const Sidebar: React.FC<SidebarProps> = ({
-  sidebarOpen, setSidebarOpen, sidebarFloat, setSidebarFloat,
-  sidebarTab, setSidebarTab, tab, setTab, scenes, selectedSceneId,
-  manuscripts, sceneSearch, setSceneSearch, newScene, setNewScene,
-  addingScene, setAddingScene, addingChapter, setAddingChapter,
-  settings, setSettings, editorSettings, setEditorSettings,
-  handleSceneSelect, handleAddScene,
-  aiHistory, onInsertHistory, onClearHistory,
-}) => {
+export const Sidebar: React.FC = () => {
+  const {
+    sidebarOpen, setSidebarOpen, sidebarFloat, setSidebarFloat,
+    sidebarTab, setSidebarTab, tab, setTab, scenes, selectedSceneId,
+    manuscripts, sceneSearch, setSceneSearch, newScene, setNewScene,
+    addingScene, setAddingScene, addingChapter, setAddingChapter,
+    settings, setSettings, editorSettings, setEditorSettings,
+    handleSceneSelect, handleAddScene,
+    aiHistory, clearAiHistory, manuscriptText, handleManuscriptChange
+  } = useStudio();
   const [expandedIds, setExpandedIds] = useState<number[]>([]);
 
   const toggleExpand = (id: number) => {
     setExpandedIds(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
+  };
+
+  const onInsertHistory = (content: string) => {
+    handleManuscriptChange(manuscriptText + (manuscriptText ? "\n" : "") + content);
   };
 
   return (
@@ -205,7 +180,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <div style={{ display: "flex", alignItems: "center", marginBottom: 4 }}>
                 <span style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", flex: 1 }}>AI 履歴</span>
                 {aiHistory.length > 0 && (
-                  <button onClick={onClearHistory} style={{ fontSize: 9, padding: "2px 7px", background: "transparent", border: "1px solid #1e2d42", color: "#2a4060", borderRadius: 3, cursor: "pointer", fontFamily: "inherit" }}>全クリア</button>
+                  <button onClick={clearAiHistory} style={{ fontSize: 9, padding: "2px 7px", background: "transparent", border: "1px solid #1e2d42", color: "#2a4060", borderRadius: 3, cursor: "pointer", fontFamily: "inherit" }}>全クリア</button>
                 )}
               </div>
               {aiHistory.length === 0 ? (

--- a/src/components/modals/BackupModal.tsx
+++ b/src/components/modals/BackupModal.tsx
@@ -1,27 +1,17 @@
 import { useRef, useState } from "react";
-import { Scene, Settings, Manuscripts, Backup } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-type BackupModalProps = {
-  backups: Backup[];
-  autoBackups: Backup[];
-  _scenes: Scene[];
-  _settings: Settings;
-  _manuscripts: Manuscripts;
-  onRestore: (scenes: Scene[], manuscripts: Manuscripts, settings?: Settings, projectTitle?: string) => void;
-  onSaveBackup: (label: string | null) => void;
-  onClose: () => void;
-};
-
-export function BackupModal({
-  backups,
-  autoBackups,
-  _scenes,
-  _settings,
-  _manuscripts,
-  onRestore,
-  onSaveBackup,
-  onClose,
-}: BackupModalProps) {
+export function BackupModal() {
+  const {
+    backups,
+    autoBackups,
+    setScenes,
+    setManuscripts,
+    setSettings,
+    setProjectTitle,
+    handleSaveBackup,
+    setShowBackups
+  } = useStudio();
   const backupLabelRef = useRef<HTMLInputElement>(null);
   const [track, setTrack] = useState<"manual" | "auto">("manual");
 
@@ -81,7 +71,7 @@ export function BackupModal({
             <button
               onClick={() => {
                 const label = backupLabelRef.current?.value || null;
-                onSaveBackup(label);
+                handleSaveBackup(label);
                 if (backupLabelRef.current) backupLabelRef.current.value = "";
               }}
               style={{
@@ -134,7 +124,13 @@ export function BackupModal({
                     </div>
                   </div>
                   <button
-                    onClick={() => onRestore(bk.scenes || [], bk.manuscripts || {}, bk.settings, bk.projectTitle)}
+                    onClick={() => {
+                      setScenes(bk.scenes || []);
+                      setManuscripts(bk.manuscripts || {});
+                      if (bk.settings) setSettings(bk.settings);
+                      if (bk.projectTitle) setProjectTitle(bk.projectTitle);
+                      setShowBackups(false);
+                    }}
                     style={{
                       padding: "4px 12px",
                       background: "rgba(74,111,165,0.15)",
@@ -154,7 +150,7 @@ export function BackupModal({
           </div>
         )}
         <button
-          onClick={onClose}
+          onClick={() => setShowBackups(false)}
           style={{
             width: "100%",
             padding: "7px",

--- a/src/components/modals/DeleteConfirmModal.tsx
+++ b/src/components/modals/DeleteConfirmModal.tsx
@@ -1,12 +1,9 @@
-import { Scene } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-type DeleteConfirmModalProps = {
-  scene: Scene | undefined;
-  onConfirm: () => void;
-  onCancel: () => void;
-};
+export function DeleteConfirmModal() {
+  const { scenes, confirmDelete, setConfirmDelete, confirmDeleteExecute } = useStudio();
+  const scene = scenes.find((s) => s.id === confirmDelete);
 
-export function DeleteConfirmModal({ scene, onConfirm, onCancel }: DeleteConfirmModalProps) {
   if (!scene) return null;
 
   return (
@@ -37,7 +34,7 @@ export function DeleteConfirmModal({ scene, onConfirm, onCancel }: DeleteConfirm
         <div style={{ fontSize: 12, color: "#3a5570", marginBottom: 24 }}>この操作は取り消せません。</div>
         <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
           <button
-            onClick={onCancel}
+            onClick={() => setConfirmDelete(null)}
             style={{
               padding: "7px 20px",
               background: "transparent",
@@ -52,7 +49,7 @@ export function DeleteConfirmModal({ scene, onConfirm, onCancel }: DeleteConfirm
             キャンセル
           </button>
           <button
-            onClick={onConfirm}
+            onClick={confirmDeleteExecute}
             style={{
               padding: "7px 20px",
               background: "rgba(180,40,40,0.2)",

--- a/src/components/modals/ExportModal.tsx
+++ b/src/components/modals/ExportModal.tsx
@@ -1,20 +1,13 @@
-import { Scene } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-type ExportModalProps = {
-  selectedScene: Scene | null;
-  _projectTitle: string;
-  onExportScene: (fmt: "md" | "txt") => void;
-  onExportAll: (fmt: "md" | "txt") => void;
-  onClose: () => void;
-};
+export function ExportModal() {
+  const {
+    selectedScene,
+    exportScene,
+    exportAll,
+    setShowExport
+  } = useStudio();
 
-export function ExportModal({
-  selectedScene,
-  _projectTitle,
-  onExportScene,
-  onExportAll,
-  onClose,
-}: ExportModalProps) {
   return (
     <div
       style={{
@@ -34,7 +27,7 @@ export function ExportModal({
             <div style={{ fontSize: 11, color: "#3a5570", marginBottom: 10 }}>選択中のシーン：「{selectedScene.title}」</div>
             <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
               <button
-                onClick={() => onExportScene("md")}
+                onClick={() => exportScene("md")}
                 style={{
                   flex: 1,
                   padding: "8px",
@@ -50,7 +43,7 @@ export function ExportModal({
                 .md
               </button>
               <button
-                onClick={() => onExportScene("txt")}
+                onClick={() => exportScene("txt")}
                 style={{
                   flex: 1,
                   padding: "8px",
@@ -71,7 +64,7 @@ export function ExportModal({
         <div style={{ fontSize: 11, color: "#3a5570", marginBottom: 10 }}>全シーンまとめて</div>
         <div style={{ display: "flex", gap: 8, marginBottom: 24 }}>
           <button
-            onClick={() => onExportAll("md")}
+            onClick={() => exportAll("md")}
             style={{
               flex: 1,
               padding: "8px",
@@ -87,7 +80,7 @@ export function ExportModal({
             .md
           </button>
           <button
-            onClick={() => onExportAll("txt")}
+            onClick={() => exportAll("txt")}
             style={{
               flex: 1,
               padding: "8px",
@@ -104,7 +97,7 @@ export function ExportModal({
           </button>
         </div>
         <button
-          onClick={onClose}
+          onClick={() => setShowExport(false)}
           style={{
             width: "100%",
             padding: "7px",

--- a/src/components/views/PrefsView.tsx
+++ b/src/components/views/PrefsView.tsx
@@ -1,14 +1,8 @@
 import React from "react";
-import type { EditorSettings } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-interface PrefsViewProps {
-  editorSettings: EditorSettings;
-  setEditorSettings: React.Dispatch<React.SetStateAction<EditorSettings>>;
-}
-
-export const PrefsView: React.FC<PrefsViewProps> = ({
-  editorSettings, setEditorSettings
-}) => {
+export const PrefsView: React.FC = () => {
+  const { editorSettings, setEditorSettings } = useStudio();
   return (
     <div style={{ padding: "24px 32px", overflowY: "auto" }}>
       <h2 style={{ margin: "0 0 24px", fontSize: 16, color: "#7ab3e0", fontWeight: 400, letterSpacing: 2 }}>環境設定</h2>

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -1,25 +1,14 @@
 import React from "react";
 import { AiPanel } from "../ai/AiPanel";
-import type { Settings, AiResults, AiLoading, AiErrors } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-interface SettingsViewProps {
-  settings: Settings;
-  setSettings: React.Dispatch<React.SetStateAction<Settings>>;
-  settingsTab: keyof Settings;
-  setSettingsTab: (v: keyof Settings) => void;
-  aiResults: AiResults;
-  setAiResults: React.Dispatch<React.SetStateAction<AiResults>>;
-  aiErrors: AiErrors;
-  setAiErrors: React.Dispatch<React.SetStateAction<AiErrors>>;
-  aiLoading: AiLoading;
-  setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
-}
+export const SettingsView: React.FC = () => {
+  const {
+    settings, setSettings, settingsTab, setSettingsTab,
+    aiResults, setAiResults, aiErrors, setAiErrors,
+    aiLoading, setAiLoading
+  } = useStudio();
 
-export const SettingsView: React.FC<SettingsViewProps> = ({
-  settings, setSettings, settingsTab, setSettingsTab,
-  aiResults, setAiResults, aiErrors, setAiErrors,
-  aiLoading, setAiLoading
-}) => {
   return (
     <div style={{ padding: "24px 32px", overflowY: "auto" }}>
       <h2 style={{ margin: "0 0 16px", fontSize: 16, color: "#7ab3e0", fontWeight: 400, letterSpacing: 2 }}>世界観メモ</h2>

--- a/src/components/views/StructureView.tsx
+++ b/src/components/views/StructureView.tsx
@@ -1,27 +1,14 @@
 import React, { useState } from "react";
 import { statusColors, statusLabels } from "../../constants";
-import type { Scene, Manuscripts, SceneDraft } from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
+import type { Scene } from "../../types";
 
-interface StructureViewProps {
-  scenes: Scene[];
-  setScenes: React.Dispatch<React.SetStateAction<Scene[]>>;
-  manuscripts: Manuscripts;
-  addingScene: boolean;
-  setAddingScene: (v: boolean) => void;
-  newScene: SceneDraft;
-  setNewScene: (v: SceneDraft) => void;
-  handleAddScene: () => void;
-  addingChapter: boolean;
-  setAddingChapter: (v: boolean) => void;
-  handleSceneSelect: (s: Scene) => void;
-  selectedSceneId: number | null;
-}
-
-export const StructureView: React.FC<StructureViewProps> = ({
-  scenes, setScenes, manuscripts, addingScene, setAddingScene,
-  newScene, setNewScene, handleAddScene, addingChapter,
-  setAddingChapter, handleSceneSelect, selectedSceneId
-}) => {
+export const StructureView: React.FC = () => {
+  const {
+    scenes, setScenes, manuscripts, addingScene, setAddingScene,
+    newScene, setNewScene, handleAddScene, addingChapter,
+    setAddingChapter, handleSceneSelect, selectedSceneId
+  } = useStudio();
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropTarget, setDropTarget] = useState<{ id: number; position: "before" | "after" } | null>(null);
   const [dropChapter, setDropChapter] = useState<string | null>(null);

--- a/src/components/views/WriteView.tsx
+++ b/src/components/views/WriteView.tsx
@@ -2,48 +2,19 @@ import React, { useState } from "react";
 import { VerticalEditor } from "../editor/VerticalEditor";
 import { AiPanel } from "../ai/AiPanel";
 import { statusColors, statusLabels } from "../../constants";
-import type {
-  Scene, EditorSettings, AiResults, AiLoading, Settings, SceneStatus, AiErrors
-} from "../../types";
+import { useStudio } from "../../contexts/StudioContext";
 
-interface WriteViewProps {
-  selectedScene: Scene | null;
-  scenes: Scene[];
-  setScenes: React.Dispatch<React.SetStateAction<Scene[]>>;
-  selectedSceneId: number | null;
-  editingSceneTitle: boolean;
-  setEditingSceneTitle: (v: boolean) => void;
-  editingSceneSynopsis: boolean;
-  setEditingSceneSynopsis: (v: boolean) => void;
-  handleStatusChange: (id: number, status: SceneStatus) => void;
-  verticalPreview: boolean;
-  setVerticalPreview: (v: boolean) => void;
-  handleDeleteScene: (id: number) => void;
-  manuscriptText: string;
-  handleManuscriptChange: (text: string) => void;
-  editorSettings: EditorSettings;
-  handleSceneSelect: (s: Scene) => void;
-  wordCount: number;
-  aiResults: AiResults;
-  setAiResults: React.Dispatch<React.SetStateAction<AiResults>>;
-  aiErrors: AiErrors;
-  setAiErrors: React.Dispatch<React.SetStateAction<AiErrors>>;
-  aiLoading: AiLoading;
-  setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
-  settings: Settings;
-  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
-}
-
-export const WriteView: React.FC<WriteViewProps> = ({
-  selectedScene, scenes, setScenes, selectedSceneId,
-  editingSceneTitle, setEditingSceneTitle,
-  editingSceneSynopsis, setEditingSceneSynopsis,
-  handleStatusChange, verticalPreview, setVerticalPreview,
-  handleDeleteScene, manuscriptText, handleManuscriptChange,
-  editorSettings, handleSceneSelect, wordCount,
-  aiResults, setAiResults, aiErrors, setAiErrors,
-  aiLoading, setAiLoading, settings, addAiHistory
-}) => {
+export const WriteView: React.FC = () => {
+  const {
+    selectedScene, scenes, setScenes, selectedSceneId,
+    editingSceneTitle, setEditingSceneTitle,
+    editingSceneSynopsis, setEditingSceneSynopsis,
+    handleStatusChange, verticalPreview, setVerticalPreview,
+    handleDeleteScene, manuscriptText, handleManuscriptChange,
+    editorSettings, handleSceneSelect, wordCount,
+    aiResults, setAiResults, aiErrors, setAiErrors,
+    aiLoading, setAiLoading, settings, addAiHistory
+  } = useStudio();
   const [footerOpen, setFooterOpen] = useState(true);
 
   if (!selectedScene) {

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -1,76 +1,100 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo } from "react";
 import type { User } from "@supabase/supabase-js";
-import { supabase } from "../supabase";
+import { storageGet, storageSet } from "../utils/storage";
 import type {
   SceneStatus, Scene, Settings, Manuscripts, AppliedState,
   AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem
 } from "../types";
 import { initialSettings, initialScenes } from "../constants";
 
-interface StoredData<T> {
-  value: T;
-  updated_at: string;
+interface StudioContextType {
+  loaded: boolean;
+  saveStatus: SaveStatus;
+  lastSavedTime: Date | null;
+  tab: TabKey;
+  setTab: React.Dispatch<React.SetStateAction<TabKey>>;
+  settings: Settings;
+  setSettings: React.Dispatch<React.SetStateAction<Settings>>;
+  settingsTab: keyof Settings;
+  setSettingsTab: React.Dispatch<React.SetStateAction<keyof Settings>>;
+  scenes: Scene[];
+  setScenes: React.Dispatch<React.SetStateAction<Scene[]>>;
+  selectedSceneId: number | null;
+  setSelectedSceneId: React.Dispatch<React.SetStateAction<number | null>>;
+  manuscripts: Manuscripts;
+  setManuscripts: React.Dispatch<React.SetStateAction<Manuscripts>>;
+  showSettings: boolean;
+  setShowSettings: React.Dispatch<React.SetStateAction<boolean>>;
+  sidebarOpen: boolean;
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  newScene: SceneDraft;
+  setNewScene: React.Dispatch<React.SetStateAction<SceneDraft>>;
+  addingScene: boolean;
+  setAddingScene: React.Dispatch<React.SetStateAction<boolean>>;
+  confirmDelete: number | null;
+  setConfirmDelete: React.Dispatch<React.SetStateAction<number | null>>;
+  addingChapter: boolean;
+  setAddingChapter: React.Dispatch<React.SetStateAction<boolean>>;
+  projectTitle: string;
+  setProjectTitle: React.Dispatch<React.SetStateAction<string>>;
+  editingTitle: boolean;
+  setEditingTitle: React.Dispatch<React.SetStateAction<boolean>>;
+  showExport: boolean;
+  setShowExport: React.Dispatch<React.SetStateAction<boolean>>;
+  sceneSearch: string;
+  setSceneSearch: React.Dispatch<React.SetStateAction<string>>;
+  backups: Backup[];
+  setBackups: React.Dispatch<React.SetStateAction<Backup[]>>;
+  showBackups: boolean;
+  setShowBackups: React.Dispatch<React.SetStateAction<boolean>>;
+  verticalPreview: boolean;
+  setVerticalPreview: React.Dispatch<React.SetStateAction<boolean>>;
+  editingSceneTitle: boolean;
+  setEditingSceneTitle: React.Dispatch<React.SetStateAction<boolean>>;
+  editingSceneSynopsis: boolean;
+  setEditingSceneSynopsis: React.Dispatch<React.SetStateAction<boolean>>;
+  sidebarFloat: boolean;
+  setSidebarFloat: React.Dispatch<React.SetStateAction<boolean>>;
+  sidebarTab: SidebarTabKey;
+  setSidebarTab: React.Dispatch<React.SetStateAction<SidebarTabKey>>;
+  editorSettings: EditorSettings;
+  setEditorSettings: React.Dispatch<React.SetStateAction<EditorSettings>>;
+  aiFloat: boolean;
+  setAiFloat: React.Dispatch<React.SetStateAction<boolean>>;
+  aiWide: boolean;
+  setAiWide: React.Dispatch<React.SetStateAction<boolean>>;
+  aiResults: AiResults;
+  setAiResults: React.Dispatch<React.SetStateAction<AiResults>>;
+  aiErrors: AiErrors;
+  setAiErrors: React.Dispatch<React.SetStateAction<AiErrors>>;
+  aiLoading: AiLoading;
+  setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
+  aiApplied: AppliedState;
+  setAiApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
+  hintApplied: AppliedState;
+  setHintApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
+  aiHistory: AiHistoryItem[];
+  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
+  clearAiHistory: () => void;
+  autoBackups: Backup[];
+  selectedScene: Scene | null;
+  manuscriptText: string;
+  wordCount: number;
+  handleSceneSelect: (scene: Scene) => void;
+  handleManuscriptChange: (text: string) => void;
+  handleStatusChange: (id: number, status: SceneStatus) => void;
+  handleAddScene: () => void;
+  handleDeleteScene: (id: number) => void;
+  confirmDeleteExecute: () => void;
+  saveWithBackup: (sc: Scene[], st: Settings, ms: Manuscripts, pt: string, label?: string | null) => Promise<void>;
+  exportScene: (fmt: "md" | "txt") => void;
+  exportAll: (fmt: "md" | "txt") => void;
+  handleSaveBackup: (label: string | null) => void;
 }
 
-async function storageGet<T = unknown>(key: string): Promise<T | null> {
-  // 1. Get from LocalStorage
-  const localRaw = localStorage.getItem(key);
-  const localData: StoredData<T> | null = localRaw ? JSON.parse(localRaw) : null;
+const StudioContext = createContext<StudioContextType | undefined>(undefined);
 
-  try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return localData?.value || null;
-
-    // 2. Get from Supabase
-    const { data, error } = await supabase
-      .from("minato_data")
-      .select("value, updated_at")
-      .eq("user_id", user.id)
-      .eq("key", key)
-      .single();
-
-    if (error || !data) return localData?.value || null;
-
-    const remoteData: StoredData<T> = { value: data.value, updated_at: data.updated_at };
-
-    // 3. Compare timestamps
-    if (!localData || new Date(remoteData.updated_at) > new Date(localData.updated_at)) {
-      // Remote is newer or local is missing
-      localStorage.setItem(key, JSON.stringify(remoteData));
-      return remoteData.value;
-    }
-    return localData.value;
-  } catch {
-    return localData?.value || null;
-  }
-}
-
-async function storageSet(key: string, value: unknown): Promise<boolean> {
-  const updatedAt = new Date().toISOString();
-  const data = { value, updated_at: updatedAt };
-  
-  // Always save to localStorage first
-  localStorage.setItem(key, JSON.stringify(data));
-
-  try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return false;
-
-    const { error } = await supabase.from("minato_data").upsert({
-      user_id: user.id,
-      key,
-      value,
-      updated_at: updatedAt,
-    }, { onConflict: "user_id,key" });
-
-    return !error;
-  } catch (e) {
-    console.error(e);
-    return false;
-  }
-}
-
-export function useStudioState(_user: User) {
+export function StudioProvider({ children, user }: { children: React.ReactNode, user: User }) {
   const [loaded, setLoaded] = useState(false);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
@@ -108,8 +132,7 @@ export function useStudioState(_user: User) {
   const [hintApplied, setHintApplied] = useState<AppliedState>({});
   const [aiHistory, setAiHistory] = useState<AiHistoryItem[]>([]);
   const [autoBackups, setAutoBackups] = useState<Backup[]>([]);
-  const [exportContent, setExportContent] = useState<string>("");
-  const [showExportContent, setShowExportContent] = useState<boolean>(false);
+  
   const previousIsOnlineRef = useRef(navigator.onLine);
   const syncAllRef = useRef<() => Promise<void>>(async () => {});
   const latestStateRef = useRef({ scenes: initialScenes, manuscripts: {} as Manuscripts });
@@ -127,7 +150,6 @@ export function useStudioState(_user: User) {
     [manuscriptText]
   );
 
-  // Track online status
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);
@@ -141,7 +163,7 @@ export function useStudioState(_user: User) {
 
   useEffect(() => {
     (async () => {
-      setLoaded(false); // Reload data when user changes
+      setLoaded(false);
       const [sc, st, ms, pt, bk, es, ah, ab] = await Promise.all([
         storageGet<Scene[]>("minato:scenes"),
         storageGet<Settings>("minato:settings"),
@@ -162,7 +184,7 @@ export function useStudioState(_user: User) {
       if (ab) setAutoBackups(ab);
       setLoaded(true);
     })();
-  }, [_user?.id]); // Re-run when user logs in/out
+  }, [user?.id]);
 
   const syncAll = useCallback(async () => {
     if (!loaded) return;
@@ -201,7 +223,6 @@ export function useStudioState(_user: User) {
     return () => clearTimeout(t);
   }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, loaded, syncAll]);
 
-  // Force sync when coming back online
   useEffect(() => {
     if (!loaded) return;
     const wasOnline = previousIsOnlineRef.current;
@@ -235,7 +256,6 @@ export function useStudioState(_user: User) {
     } catch { setSaveStatus("error"); }
   };
 
-  // Keep latestStateRef current for use in the auto-backup timer
   useEffect(() => { latestStateRef.current = { scenes, manuscripts }; }, [scenes, manuscripts]);
 
   const addAiHistory = useCallback((label: string, content: string, sceneTitle?: string) => {
@@ -246,7 +266,6 @@ export function useStudioState(_user: User) {
 
   const clearAiHistory = useCallback(() => { setAiHistory([]); storageSet("minato:aiHistory", []); }, []);
 
-  // Auto-backup every 10 minutes
   useEffect(() => {
     if (!loaded) return;
     const timer = setInterval(() => {
@@ -277,7 +296,6 @@ export function useStudioState(_user: User) {
   };
 
   const downloadFile = (content: string, filename: string) => {
-    // UTF-8 BOM for Windows compatibility (prevents mojibake)
     const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
     const blob = new Blob([bom, content], { type: "text/plain;charset=utf-8" });
     const url = URL.createObjectURL(blob);
@@ -323,7 +341,7 @@ export function useStudioState(_user: User) {
     storageSet("minato:backups", updated);
   };
 
-  return {
+  const value: StudioContextType = {
     loaded, saveStatus, lastSavedTime, tab, setTab, settings, setSettings,
     settingsTab, setSettingsTab, scenes, setScenes, selectedSceneId, setSelectedSceneId,
     manuscripts, setManuscripts, showSettings, setShowSettings, sidebarOpen, setSidebarOpen,
@@ -341,4 +359,14 @@ export function useStudioState(_user: User) {
     handleDeleteScene, confirmDeleteExecute, saveWithBackup, exportScene, exportAll,
     handleSaveBackup
   };
+
+  return <StudioContext.Provider value={value}>{children}</StudioContext.Provider>;
+}
+
+export function useStudio() {
+  const context = useContext(StudioContext);
+  if (context === undefined) {
+    throw new Error("useStudio must be used within a StudioProvider");
+  }
+  return context;
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,59 @@
+import { supabase } from "../supabase";
+
+interface StoredData<T> {
+  value: T;
+  updated_at: string;
+}
+
+export async function storageGet<T = unknown>(key: string): Promise<T | null> {
+  const localRaw = localStorage.getItem(key);
+  const localData: StoredData<T> | null = localRaw ? JSON.parse(localRaw) : null;
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return localData?.value || null;
+
+    const { data, error } = await supabase
+      .from("minato_data")
+      .select("value, updated_at")
+      .eq("user_id", user.id)
+      .eq("key", key)
+      .single();
+
+    if (error || !data) return localData?.value || null;
+
+    const remoteData: StoredData<T> = { value: data.value, updated_at: data.updated_at };
+
+    if (!localData || new Date(remoteData.updated_at) > new Date(localData.updated_at)) {
+      localStorage.setItem(key, JSON.stringify(remoteData));
+      return remoteData.value;
+    }
+    return localData.value;
+  } catch {
+    return localData?.value || null;
+  }
+}
+
+export async function storageSet(key: string, value: unknown): Promise<boolean> {
+  const updatedAt = new Date().toISOString();
+  const data = { value, updated_at: updatedAt };
+  
+  localStorage.setItem(key, JSON.stringify(data));
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return false;
+
+    const { error } = await supabase.from("minato_data").upsert({
+      user_id: user.id,
+      key,
+      value,
+      updated_at: updatedAt,
+    }, { onConflict: "user_id,key" });
+
+    return !error;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+}


### PR DESCRIPTION
Replace the previous useStudioState hook with a React context (StudioProvider / useStudio) in contexts/StudioContext.tsx and extract storage helpers to utils/storage.ts. App is wrapped with StudioProvider and components (Header, Sidebar, WriteView, StructureView, SettingsView, PrefsView, AiAssistant, BackupModal, ExportModal, DeleteConfirmModal) were refactored to consume the context instead of receiving large prop lists, removing much prop drilling and simplifying modal handlers. Tests were updated to use the new context (including renaming and mocking where appropriate). Overall this centralizes state management and persistence logic and cleans up component interfaces.