### PR TITLE
Add theme support and persist UI prefs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__linear-server__list_issues",
+      "mcp__linear-server__get_issue",
+      "Bash(npx tsc:*)",
+      "mcp__linear-server__save_issue"
+    ]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
         overflow: hidden;
       }
       #root { height: 100dvh; display: flex; flex-direction: column; }
+      /* ライトテーマ: フィルターベース変換 */
+      html[data-theme="light"] #root {
+        filter: invert(1) hue-rotate(180deg);
+      }
+      /* フィルター適用時に画像・動画は再反転 */
+      html[data-theme="light"] img,
+      html[data-theme="light"] video {
+        filter: invert(1) hue-rotate(180deg);
+      }
     </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ export const Sidebar: React.FC = () => {
           {/* Sidebar header: tabs + close */}
           <div style={{ display: "flex", alignItems: "center", borderBottom: "1px solid #1e2d42", flexShrink: 0 }}>
             {([["write","執筆"],["structure","構成"],["settings","世界観"],["prefs","環境"],["ai","AI"]] as [SidebarTabKey, string][]).map(([key, label]) => (
-              <button key={key} onClick={() => setSidebarTab(key)} style={{
+              <button key={key} onClick={() => { setSidebarTab(key); setTab(key as TabKey); }} style={{
                 flex: 1, padding: "8px 0", background: "transparent", border: "none",
                 borderBottom: sidebarTab === key ? "2px solid #4a6fa5" : "2px solid transparent",
                 color: sidebarTab === key ? "#7ab3e0" : "#2a4060",
@@ -171,6 +171,27 @@ export const Sidebar: React.FC = () => {
                 <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>行間　<span style={{ color: "#8ab0cc" }}>{editorSettings.lineHeight}</span></div>
                 <input type="range" min={1.4} max={3.0} step={0.1} value={editorSettings.lineHeight} onChange={e => setEditorSettings(s => ({ ...s, lineHeight: Number(e.target.value) }))} style={{ width: "100%" }} />
               </div>
+              <div>
+                <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>テーマ</div>
+                <div style={{ display: "flex", gap: 4 }}>
+                  {(["dark", "light", "system"] as const).map(t => (
+                    <button
+                      key={t}
+                      onClick={() => setEditorSettings(s => ({ ...s, colorTheme: t }))}
+                      style={{
+                        flex: 1, padding: "4px 2px",
+                        background: (editorSettings.colorTheme ?? "dark") === t ? "rgba(74,111,165,0.2)" : "transparent",
+                        border: "1px solid",
+                        borderColor: (editorSettings.colorTheme ?? "dark") === t ? "#4a6fa5" : "#1e2d42",
+                        color: (editorSettings.colorTheme ?? "dark") === t ? "#7ab3e0" : "#3a5570",
+                        cursor: "pointer", fontSize: 9, borderRadius: 3, fontFamily: "inherit",
+                      }}
+                    >
+                      {t === "dark" ? "暗" : t === "light" ? "明" : "自動"}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
 
@@ -238,6 +259,7 @@ export const Sidebar: React.FC = () => {
           ].map(({ key, label }) => (
             <button key={key} onClick={() => {
               setTab(key as TabKey);
+              setSidebarTab(key as SidebarTabKey);
               if (sidebarFloat) setSidebarOpen(false);
             }} style={{
               padding: "14px 0", width: "100%", border: "none",

--- a/src/components/views/PrefsView.tsx
+++ b/src/components/views/PrefsView.tsx
@@ -20,6 +20,30 @@ export const PrefsView: React.FC = () => {
         <div style={{ padding: "12px 16px", background: "#070a14", border: "1px solid #1a2535", borderRadius: 6 }}>
           <div style={{ fontSize: editorSettings.fontSize, lineHeight: editorSettings.lineHeight, color: "#8ab0cc", fontFamily: "'Noto Serif JP','Georgia',serif" }}>プレビュー：夜明け前の霧の中、自律貨物船が静かに接岸した。</div>
         </div>
+        <div>
+          <div style={{ fontSize: 11, letterSpacing: 2, color: "#4a6fa5", marginBottom: 10 }}>テーマ</div>
+          <div style={{ display: "flex", gap: 8 }}>
+            {(["dark", "light", "system"] as const).map(t => (
+              <button
+                key={t}
+                onClick={() => setEditorSettings(s => ({ ...s, colorTheme: t }))}
+                style={{
+                  flex: 1, padding: "8px 4px",
+                  background: (editorSettings.colorTheme ?? "dark") === t ? "rgba(74,111,165,0.2)" : "transparent",
+                  border: "1px solid",
+                  borderColor: (editorSettings.colorTheme ?? "dark") === t ? "#4a6fa5" : "#1e2d42",
+                  color: (editorSettings.colorTheme ?? "dark") === t ? "#7ab3e0" : "#3a5570",
+                  cursor: "pointer", fontSize: 12, borderRadius: 4, fontFamily: "inherit",
+                }}
+              >
+                {t === "dark" ? "ダーク" : t === "light" ? "ライト" : "システム"}
+              </button>
+            ))}
+          </div>
+          <div style={{ fontSize: 10, color: "#2a4060", marginTop: 6 }}>
+            {(editorSettings.colorTheme ?? "dark") === "system" ? "OSの設定に従います" : ""}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -6,7 +6,7 @@ export const SettingsView: React.FC = () => {
   const {
     settings, setSettings, settingsTab, setSettingsTab,
     aiResults, setAiResults, aiErrors, setAiErrors,
-    aiLoading, setAiLoading
+    aiLoading, setAiLoading, addAiHistory
   } = useStudio();
 
   return (
@@ -23,7 +23,10 @@ export const SettingsView: React.FC = () => {
       <AiPanel
         label="AIで意味を拡張"
         result={aiResults.worldExpand || ""}
-        onResult={t => setAiResults(r => ({ ...r, worldExpand: t }))}
+        onResult={t => {
+          setAiResults(r => ({ ...r, worldExpand: t }));
+          if (t) addAiHistory("世界観拡張", t);
+        }}
         onLoading={v => setAiLoading(l => ({ ...l, worldExpand: v }))}
         loading={aiLoading.worldExpand}
         error={aiErrors.worldExpand}

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -122,7 +122,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
   const [editingSceneSynopsis, setEditingSceneSynopsis] = useState(false);
   const [sidebarFloat, setSidebarFloat] = useState(true);
   const [sidebarTab, setSidebarTab] = useState<SidebarTabKey>("write");
-  const [editorSettings, setEditorSettings] = useState<EditorSettings>({ fontSize: 15, lineHeight: 2.2 });
+  const [editorSettings, setEditorSettings] = useState<EditorSettings>({ fontSize: 15, lineHeight: 2.2, colorTheme: "dark" });
   const [aiFloat, setAiFloat] = useState(false);
   const [aiWide, setAiWide] = useState(false);
   const [aiResults, setAiResults] = useState<AiResults>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" });
@@ -164,7 +164,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
   useEffect(() => {
     (async () => {
       setLoaded(false);
-      const [sc, st, ms, pt, bk, es, ah, ab] = await Promise.all([
+      const [sc, st, ms, pt, bk, es, ah, ab, sf, af] = await Promise.all([
         storageGet<Scene[]>("minato:scenes"),
         storageGet<Settings>("minato:settings"),
         storageGet<Manuscripts>("minato:manuscripts"),
@@ -173,6 +173,8 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
         storageGet<EditorSettings>("minato:editorSettings"),
         storageGet<AiHistoryItem[]>("minato:aiHistory"),
         storageGet<Backup[]>("minato:autoBackups"),
+        storageGet<boolean>("minato:sidebarFloat"),
+        storageGet<boolean>("minato:aiFloat"),
       ]);
       if (sc) setScenes(sc);
       if (st) setSettings(st);
@@ -182,6 +184,8 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
       if (es) setEditorSettings(es);
       if (ah) setAiHistory(ah);
       if (ab) setAutoBackups(ab);
+      if (sf !== null) setSidebarFloat(sf);
+      if (af !== null) setAiFloat(af);
       setLoaded(true);
     })();
   }, [user?.id]);
@@ -199,6 +203,8 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
         storageSet("minato:backups", backups),
         storageSet("minato:aiHistory", aiHistory),
         storageSet("minato:autoBackups", autoBackups),
+        storageSet("minato:sidebarFloat", sidebarFloat),
+        storageSet("minato:aiFloat", aiFloat),
       ]);
 
       const allSuccess = results.every(r => r);
@@ -211,7 +217,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
     } catch {
       setSaveStatus("error");
     }
-  }, [scenes, settings, manuscripts, projectTitle, editorSettings, backups, aiHistory, autoBackups, loaded]);
+  }, [scenes, settings, manuscripts, projectTitle, editorSettings, backups, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded]);
 
   useEffect(() => {
     syncAllRef.current = syncAll;
@@ -221,7 +227,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
     if (!loaded) return;
     const t = setTimeout(syncAll, 1000);
     return () => clearTimeout(t);
-  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, loaded, syncAll]);
+  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded, syncAll]);
 
   useEffect(() => {
     if (!loaded) return;
@@ -265,6 +271,27 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
   }, []);
 
   const clearAiHistory = useCallback(() => { setAiHistory([]); storageSet("minato:aiHistory", []); }, []);
+
+  useEffect(() => {
+    const applyTheme = (theme: "dark" | "light" | "system") => {
+      if (theme === "system") {
+        const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        document.documentElement.setAttribute("data-theme", isDark ? "dark" : "light");
+      } else {
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+    };
+    const currentTheme = editorSettings.colorTheme ?? "dark";
+    applyTheme(currentTheme);
+    if (currentTheme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const handler = (e: MediaQueryListEvent) => {
+        document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
+      };
+      mq.addEventListener("change", handler);
+      return () => mq.removeEventListener("change", handler);
+    }
+  }, [editorSettings.colorTheme]);
 
   useEffect(() => {
     if (!loaded) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type HintItem = { hint: string; reason: string; keyword?: string };
 export type PolishSuggestion = { original: string; suggestion: string; reason: string };
 
 export type SceneDraft = Pick<Scene, "chapter" | "title" | "synopsis">;
-export type EditorSettings = { fontSize: number; lineHeight: number };
+export type EditorSettings = { fontSize: number; lineHeight: number; colorTheme: "dark" | "light" | "system" };
 export type TabKey = "write" | "structure" | "settings" | "prefs" | "ai";
 export type SidebarTabKey = TabKey | "ai";
 export type SaveStatus = "saving" | "saved" | "error" | "offline";


### PR DESCRIPTION
Introduce color theme controls and persistence across the app, plus other UI state persistence and minor UI tweaks. Key changes:

- Add EditorSettings.colorTheme type and default value (dark).
- Persist and restore sidebarFloat and aiFloat, include them in sync/save effects and deps.
- Add theme selection UI in Sidebar and Prefs view; update Sidebar tab handling (setTab/setSidebarTab) and small styling changes.
- Apply theme to document via data-theme attribute and handle system theme with matchMedia listener; add CSS filter inversion for "light" theme and re-inversion for images/videos in index.html.
- Record AI results into history when producing world expansion in SettingsView (addAiHistory invocation).
- Add a local .claude/settings.local.json used for permissions.

These changes enable user-selectable dark/light/system themes, ensure UI float prefs are saved, and improve AI result traceability.
YUY-13　YUY-14　YUY-15