### PR TITLE
fix(storage): タイトル空白保存と自動保存ステータスの不具合を修正 (YUY-18, YUY-19)

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock supabase so tests don't need real credentials
+vi.mock("../supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { code: "PGRST116" } }),
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    }),
+  },
+}));
+
+import { storageGet, storageSet } from "../utils/storage";
+
+describe("storageGet", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns null when key does not exist", async () => {
+    const result = await storageGet("missing-key");
+    expect(result).toBeNull();
+  });
+
+  it("returns the stored value for a normal string", async () => {
+    await storageSet("test-key", "hello");
+    const result = await storageGet<string>("test-key");
+    expect(result).toBe("hello");
+  });
+
+  it("returns empty string when title was saved as empty string (YUY-18)", async () => {
+    // Simulate user clearing the project title
+    await storageSet("minato:title", "");
+    const result = await storageGet<string>("minato:title");
+    // Must return "" not null, so the app restores the blank title
+    expect(result).toBe("");
+  });
+
+  it("returns false when a boolean false was stored", async () => {
+    await storageSet("minato:sidebarFloat", false);
+    const result = await storageGet<boolean>("minato:sidebarFloat");
+    expect(result).toBe(false);
+  });
+
+  it("returns 0 when numeric zero was stored", async () => {
+    await storageSet("test-zero", 0);
+    const result = await storageGet<number>("test-zero");
+    expect(result).toBe(0);
+  });
+});
+
+describe("storageSet", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns true even when Supabase has no authenticated user (YUY-19)", async () => {
+    // Supabase mock returns user: null (not authenticated)
+    const result = await storageSet("minato:title", "テスト");
+    // Should return true because localStorage save succeeded
+    expect(result).toBe(true);
+  });
+
+  it("persists data to localStorage regardless of Supabase status", async () => {
+    await storageSet("minato:title", "テスト作品");
+    const raw = localStorage.getItem("minato:title");
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.value).toBe("テスト作品");
+  });
+
+  it("persists empty string to localStorage (YUY-18)", async () => {
+    await storageSet("minato:title", "");
+    const raw = localStorage.getItem("minato:title");
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.value).toBe("");
+  });
+});

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -179,7 +179,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
       if (sc) setScenes(sc);
       if (st) setSettings(st);
       if (ms) setManuscripts(ms);
-      if (pt) setProjectTitle(pt);
+      if (pt !== null) setProjectTitle(pt);
       if (bk) setBackups(bk);
       if (es) setEditorSettings(es);
       if (ah) setAiHistory(ah);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -11,7 +11,8 @@ export async function storageGet<T = unknown>(key: string): Promise<T | null> {
 
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return localData?.value || null;
+    // Use ?? (nullish coalescing) so falsy values like "" or false are preserved
+    if (!user) return localData != null ? localData.value : null;
 
     const { data, error } = await supabase
       .from("minato_data")
@@ -20,7 +21,7 @@ export async function storageGet<T = unknown>(key: string): Promise<T | null> {
       .eq("key", key)
       .single();
 
-    if (error || !data) return localData?.value || null;
+    if (error || !data) return localData != null ? localData.value : null;
 
     const remoteData: StoredData<T> = { value: data.value, updated_at: data.updated_at };
 
@@ -30,30 +31,36 @@ export async function storageGet<T = unknown>(key: string): Promise<T | null> {
     }
     return localData.value;
   } catch {
-    return localData?.value || null;
+    return localData != null ? localData.value : null;
   }
 }
 
 export async function storageSet(key: string, value: unknown): Promise<boolean> {
   const updatedAt = new Date().toISOString();
   const data = { value, updated_at: updatedAt };
-  
-  localStorage.setItem(key, JSON.stringify(data));
 
+  // localStorage is the primary store. Write it first and treat its success as the save result.
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return false;
-
-    const { error } = await supabase.from("minato_data").upsert({
-      user_id: user.id,
-      key,
-      value,
-      updated_at: updatedAt,
-    }, { onConflict: "user_id,key" });
-
-    return !error;
-  } catch (e) {
-    console.error(e);
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch {
+    // localStorage unavailable or quota exceeded
     return false;
   }
+
+  // Supabase sync is best-effort. Failures do not affect the return value.
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await supabase.from("minato_data").upsert({
+        user_id: user.id,
+        key,
+        value,
+        updated_at: updatedAt,
+      }, { onConflict: "user_id,key" });
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  return true;
 }


### PR DESCRIPTION
- [YUY-18/#65] storageGet の `|| null` を `!= null ? .value : null` に変更 空文字列・false・0 などの falsy 値が null として返されていたバグを修正
- [YUY-18/#65] StudioContext: `if (pt)` を `if (pt !== null)` に変更 storageGet が "" を返してもタイトルに反映されるよう修正
- [YUY-19/#66] storageSet の自動保存ロジックを統一 localStorage 書き込み成功を保存成功とみなす（Supabase 同期は best-effort） Supabase 未認証・失敗時もヘッダに「エラー」ではなく「保存済み」が表示される
- storage.ts のリグレッションテストを追加 (8件)

https://claude.ai/code/session_01E5SSpHvTVKQAMNHkN9G4GL