### PR TITLE
refactor: StudioContext を zustand に移行

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@eslint/js": "9.11.1",
@@ -3214,14 +3215,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4449,7 +4450,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -9808,6 +9809,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/js": "9.11.1",

--- a/src/__tests__/StudioContext.test.tsx
+++ b/src/__tests__/StudioContext.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { User } from "@supabase/supabase-js";
 
 // Mock supabase module
@@ -19,6 +19,7 @@ vi.mock("../supabase", () => ({
 }));
 
 import { StudioProvider, useStudio } from "../contexts/StudioContext";
+import { resetStudioStore } from "../stores/useStudioStore";
 import { initialScenes } from "../constants";
 
 const mockUser = { id: "user-1" } as User;
@@ -31,6 +32,11 @@ describe("StudioContext", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
+    resetStudioStore();
+  });
+
+  afterEach(() => {
+    resetStudioStore();
   });
 
   it("initializes with default scenes", async () => {

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -1,169 +1,29 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo } from "react";
+/**
+ * StudioContext — compatibility shim
+ *
+ * State は useStudioStore (zustand) が保持する。
+ * このファイルは:
+ *   1. StudioProvider: データロード・副作用（自動保存・テーマ・オフライン同期）を担当
+ *   2. useStudio(): useStudioStore() の再エクスポート（既存コンポーネントを無変更で使える）
+ */
+import React, { useEffect, useRef } from "react";
 import type { User } from "@supabase/supabase-js";
 import { storageGet, storageSet } from "../utils/storage";
-import type {
-  SceneStatus, Scene, Settings, Manuscripts, AppliedState,
-  AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem
-} from "../types";
-import { initialSettings, initialScenes } from "../constants";
+import type { Scene, Settings, Manuscripts, EditorSettings, AiHistoryItem, Backup } from "../types";
+import { useStudioStore } from "../stores/useStudioStore";
 
-interface StudioContextType {
-  loaded: boolean;
-  saveStatus: SaveStatus;
-  lastSavedTime: Date | null;
-  tab: TabKey;
-  setTab: React.Dispatch<React.SetStateAction<TabKey>>;
-  settings: Settings;
-  setSettings: React.Dispatch<React.SetStateAction<Settings>>;
-  settingsTab: keyof Settings;
-  setSettingsTab: React.Dispatch<React.SetStateAction<keyof Settings>>;
-  scenes: Scene[];
-  setScenes: React.Dispatch<React.SetStateAction<Scene[]>>;
-  selectedSceneId: number | null;
-  setSelectedSceneId: React.Dispatch<React.SetStateAction<number | null>>;
-  manuscripts: Manuscripts;
-  setManuscripts: React.Dispatch<React.SetStateAction<Manuscripts>>;
-  showSettings: boolean;
-  setShowSettings: React.Dispatch<React.SetStateAction<boolean>>;
-  sidebarOpen: boolean;
-  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  newScene: SceneDraft;
-  setNewScene: React.Dispatch<React.SetStateAction<SceneDraft>>;
-  addingScene: boolean;
-  setAddingScene: React.Dispatch<React.SetStateAction<boolean>>;
-  confirmDelete: number | null;
-  setConfirmDelete: React.Dispatch<React.SetStateAction<number | null>>;
-  addingChapter: boolean;
-  setAddingChapter: React.Dispatch<React.SetStateAction<boolean>>;
-  projectTitle: string;
-  setProjectTitle: React.Dispatch<React.SetStateAction<string>>;
-  editingTitle: boolean;
-  setEditingTitle: React.Dispatch<React.SetStateAction<boolean>>;
-  showExport: boolean;
-  setShowExport: React.Dispatch<React.SetStateAction<boolean>>;
-  sceneSearch: string;
-  setSceneSearch: React.Dispatch<React.SetStateAction<string>>;
-  backups: Backup[];
-  setBackups: React.Dispatch<React.SetStateAction<Backup[]>>;
-  showBackups: boolean;
-  setShowBackups: React.Dispatch<React.SetStateAction<boolean>>;
-  verticalPreview: boolean;
-  setVerticalPreview: React.Dispatch<React.SetStateAction<boolean>>;
-  editingSceneTitle: boolean;
-  setEditingSceneTitle: React.Dispatch<React.SetStateAction<boolean>>;
-  editingSceneSynopsis: boolean;
-  setEditingSceneSynopsis: React.Dispatch<React.SetStateAction<boolean>>;
-  sidebarFloat: boolean;
-  setSidebarFloat: React.Dispatch<React.SetStateAction<boolean>>;
-  sidebarTab: SidebarTabKey;
-  setSidebarTab: React.Dispatch<React.SetStateAction<SidebarTabKey>>;
-  editorSettings: EditorSettings;
-  setEditorSettings: React.Dispatch<React.SetStateAction<EditorSettings>>;
-  aiFloat: boolean;
-  setAiFloat: React.Dispatch<React.SetStateAction<boolean>>;
-  aiWide: boolean;
-  setAiWide: React.Dispatch<React.SetStateAction<boolean>>;
-  aiResults: AiResults;
-  setAiResults: React.Dispatch<React.SetStateAction<AiResults>>;
-  aiErrors: AiErrors;
-  setAiErrors: React.Dispatch<React.SetStateAction<AiErrors>>;
-  aiLoading: AiLoading;
-  setAiLoading: React.Dispatch<React.SetStateAction<AiLoading>>;
-  aiApplied: AppliedState;
-  setAiApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
-  hintApplied: AppliedState;
-  setHintApplied: React.Dispatch<React.SetStateAction<AppliedState>>;
-  aiHistory: AiHistoryItem[];
-  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
-  clearAiHistory: () => void;
-  autoBackups: Backup[];
-  selectedScene: Scene | null;
-  manuscriptText: string;
-  wordCount: number;
-  handleSceneSelect: (scene: Scene) => void;
-  handleManuscriptChange: (text: string) => void;
-  handleStatusChange: (id: number, status: SceneStatus) => void;
-  handleAddScene: () => void;
-  handleDeleteScene: (id: number) => void;
-  confirmDeleteExecute: () => void;
-  saveWithBackup: (sc: Scene[], st: Settings, ms: Manuscripts, pt: string, label?: string | null) => Promise<void>;
-  exportScene: (fmt: "md" | "txt") => void;
-  exportAll: (fmt: "md" | "txt") => void;
-  handleSaveBackup: (label: string | null) => void;
-}
+// ---------------------------------------------------------------------------
+// Provider: side effects only
+// ---------------------------------------------------------------------------
 
-const StudioContext = createContext<StudioContextType | undefined>(undefined);
-
-export function StudioProvider({ children, user }: { children: React.ReactNode, user: User }) {
-  const [loaded, setLoaded] = useState(false);
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
-  const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
-  const [lastSavedTime, setLastSavedTime] = useState<Date | null>(null);
-  const [tab, setTab] = useState<TabKey>("write");
-  const [settings, setSettings] = useState(initialSettings);
-  const [settingsTab, setSettingsTab] = useState<keyof Settings>("world");
-  const [scenes, setScenes] = useState(initialScenes);
-  const [selectedSceneId, setSelectedSceneId] = useState<number | null>(null);
-  const [manuscripts, setManuscripts] = useState<Manuscripts>({});
-  const [showSettings, setShowSettings] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [newScene, setNewScene] = useState<SceneDraft>({ chapter: "", title: "", synopsis: "" });
-  const [addingScene, setAddingScene] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
-  const [addingChapter, setAddingChapter] = useState(false);
-  const [projectTitle, setProjectTitle] = useState("港に届いた例外");
-  const [editingTitle, setEditingTitle] = useState(false);
-  const [showExport, setShowExport] = useState(false);
-  const [sceneSearch, setSceneSearch] = useState("");
-  const [backups, setBackups] = useState<Backup[]>([]);
-  const [showBackups, setShowBackups] = useState(false);
-  const [verticalPreview, setVerticalPreview] = useState(false);
-  const [editingSceneTitle, setEditingSceneTitle] = useState(false);
-  const [editingSceneSynopsis, setEditingSceneSynopsis] = useState(false);
-  const [sidebarFloat, setSidebarFloat] = useState(true);
-  const [sidebarTab, setSidebarTab] = useState<SidebarTabKey>("write");
-  const [editorSettings, setEditorSettings] = useState<EditorSettings>({ fontSize: 15, lineHeight: 2.2, colorTheme: "dark" });
-  const [aiFloat, setAiFloat] = useState(false);
-  const [aiWide, setAiWide] = useState(false);
-  const [aiResults, setAiResults] = useState<AiResults>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" });
-  const [aiErrors, setAiErrors] = useState<AiErrors>({ polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" });
-  const [aiLoading, setAiLoading] = useState<AiLoading>({ polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false });
-  const [aiApplied, setAiApplied] = useState<AppliedState>({});
-  const [hintApplied, setHintApplied] = useState<AppliedState>({});
-  const [aiHistory, setAiHistory] = useState<AiHistoryItem[]>([]);
-  const [autoBackups, setAutoBackups] = useState<Backup[]>([]);
-  
-  const previousIsOnlineRef = useRef(navigator.onLine);
+export function StudioProvider({ children, user }: { children: React.ReactNode; user: User }) {
+  const store = useStudioStore();
   const syncAllRef = useRef<() => Promise<void>>(async () => {});
-  const latestStateRef = useRef({ scenes: initialScenes, manuscripts: {} as Manuscripts });
 
-  const selectedScene = useMemo(
-    () => scenes.find(s => s.id === selectedSceneId) ?? null,
-    [scenes, selectedSceneId]
-  );
-  const manuscriptText = useMemo(
-    () => (selectedSceneId ? (manuscripts[selectedSceneId] ?? "") : ""),
-    [manuscripts, selectedSceneId]
-  );
-  const wordCount = useMemo(
-    () => manuscriptText.replace(/\s/g, "").length,
-    [manuscriptText]
-  );
-
-  useEffect(() => {
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-    return () => {
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-    };
-  }, []);
-
+  // --- Initial load ---
   useEffect(() => {
     (async () => {
-      setLoaded(false);
+      store.setLoaded(false);
       const [sc, st, ms, pt, bk, es, ah, ab, sf, af] = await Promise.all([
         storageGet<Scene[]>("minato:scenes"),
         storageGet<Settings>("minato:settings"),
@@ -176,224 +36,109 @@ export function StudioProvider({ children, user }: { children: React.ReactNode, 
         storageGet<boolean>("minato:sidebarFloat"),
         storageGet<boolean>("minato:aiFloat"),
       ]);
-      if (sc) setScenes(sc);
-      if (st) setSettings(st);
-      if (ms) setManuscripts(ms);
-      if (pt !== null) setProjectTitle(pt);
-      if (bk) setBackups(bk);
-      if (es) setEditorSettings(es);
-      if (ah) setAiHistory(ah);
-      if (ab) setAutoBackups(ab);
-      if (sf !== null) setSidebarFloat(sf);
-      if (af !== null) setAiFloat(af);
-      setLoaded(true);
+      if (sc) store.setScenes(sc);
+      if (st) store.setSettings(st);
+      if (ms) store.setManuscripts(ms);
+      if (pt !== null) store.setProjectTitle(pt);
+      if (bk) store.setBackups(bk);
+      if (es) store.setEditorSettings(es);
+      if (ah) store.setAiHistory(ah);
+      if (ab) store.setAutoBackups(ab);
+      if (sf !== null) store.setSidebarFloat(sf);
+      if (af !== null) store.setAiFloat(af);
+      store.setLoaded(true);
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id]);
 
-  const syncAll = useCallback(async () => {
-    if (!loaded) return;
-    setSaveStatus("saving");
-    try {
-      const results = await Promise.all([
-        storageSet("minato:scenes", scenes),
-        storageSet("minato:settings", settings),
-        storageSet("minato:manuscripts", manuscripts),
-        storageSet("minato:title", projectTitle),
-        storageSet("minato:editorSettings", editorSettings),
-        storageSet("minato:backups", backups),
-        storageSet("minato:aiHistory", aiHistory),
-        storageSet("minato:autoBackups", autoBackups),
-        storageSet("minato:sidebarFloat", sidebarFloat),
-        storageSet("minato:aiFloat", aiFloat),
-      ]);
-
-      const allSuccess = results.every(r => r);
-      if (allSuccess) {
-        setSaveStatus("saved");
-        setLastSavedTime(new Date());
-      } else {
-        setSaveStatus(navigator.onLine ? "error" : "offline");
-      }
-    } catch {
-      setSaveStatus("error");
-    }
-  }, [scenes, settings, manuscripts, projectTitle, editorSettings, backups, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded]);
-
-  useEffect(() => {
-    syncAllRef.current = syncAll;
-  }, [syncAll]);
+  // --- Auto-save (debounced 1 s) ---
+  const { scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded } = store;
 
   useEffect(() => {
     if (!loaded) return;
-    const t = setTimeout(syncAll, 1000);
-    return () => clearTimeout(t);
-  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded, syncAll]);
-
-  useEffect(() => {
-    if (!loaded) return;
-    const wasOnline = previousIsOnlineRef.current;
-    if (!wasOnline && isOnline) {
-      syncAllRef.current();
-    }
-    previousIsOnlineRef.current = isOnline;
-  }, [isOnline, loaded]);
-
-  const saveWithBackup = async (sc: Scene[], st: Settings, ms: Manuscripts, pt: string, label: string | null = null) => {
-    setSaveStatus("saving");
-    try {
-      const newBackup = { timestamp: new Date().toISOString(), label, scenes: sc, manuscripts: ms, settings: st, projectTitle: pt };
-      const updatedBackups = [newBackup, ...backups].slice(0, 5);
-      setBackups(updatedBackups);
-      
-      const success = await Promise.all([
-        storageSet("minato:scenes", sc),
-        storageSet("minato:settings", st),
-        storageSet("minato:manuscripts", ms),
-        storageSet("minato:title", pt),
-        storageSet("minato:backups", updatedBackups),
-      ]);
-
-      if (success.every(r => r)) {
-        setSaveStatus("saved");
-        setLastSavedTime(new Date());
-      } else {
-        setSaveStatus(navigator.onLine ? "error" : "offline");
-      }
-    } catch { setSaveStatus("error"); }
-  };
-
-  useEffect(() => { latestStateRef.current = { scenes, manuscripts }; }, [scenes, manuscripts]);
-
-  const addAiHistory = useCallback((label: string, content: string, sceneTitle?: string) => {
-    if (!content.trim()) return;
-    const item: AiHistoryItem = { id: Date.now(), timestamp: new Date().toISOString(), label, content, sceneTitle };
-    setAiHistory(prev => [item, ...prev].slice(0, 30));
-  }, []);
-
-  const clearAiHistory = useCallback(() => { setAiHistory([]); storageSet("minato:aiHistory", []); }, []);
-
-  useEffect(() => {
-    const applyTheme = (theme: "dark" | "light" | "system") => {
-      if (theme === "system") {
-        const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        document.documentElement.setAttribute("data-theme", isDark ? "dark" : "light");
-      } else {
-        document.documentElement.setAttribute("data-theme", theme);
+    const syncAll = async () => {
+      store.setSaveStatus("saving");
+      try {
+        const results = await Promise.all([
+          storageSet("minato:scenes", scenes),
+          storageSet("minato:settings", settings),
+          storageSet("minato:manuscripts", manuscripts),
+          storageSet("minato:title", projectTitle),
+          storageSet("minato:editorSettings", editorSettings),
+          storageSet("minato:backups", useStudioStore.getState().backups),
+          storageSet("minato:aiHistory", aiHistory),
+          storageSet("minato:autoBackups", autoBackups),
+          storageSet("minato:sidebarFloat", sidebarFloat),
+          storageSet("minato:aiFloat", aiFloat),
+        ]);
+        if (results.every(r => r)) {
+          store.setSaveStatus("saved");
+          store.setLastSavedTime(new Date());
+        } else {
+          store.setSaveStatus(navigator.onLine ? "error" : "offline");
+        }
+      } catch {
+        store.setSaveStatus("error");
       }
     };
-    const currentTheme = editorSettings.colorTheme ?? "dark";
-    applyTheme(currentTheme);
-    if (currentTheme === "system") {
+    syncAllRef.current = syncAll;
+    const t = setTimeout(syncAll, 1000);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded]);
+
+  // --- Online / offline sync ---
+  useEffect(() => {
+    let isOnline = navigator.onLine;
+    const handleOnline = () => {
+      if (!isOnline) syncAllRef.current();
+      isOnline = true;
+    };
+    const handleOffline = () => { isOnline = false; };
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  // --- Theme ---
+  useEffect(() => {
+    const theme = editorSettings.colorTheme ?? "dark";
+    const apply = (t: "dark" | "light" | "system") => {
+      if (t === "system") {
+        document.documentElement.setAttribute("data-theme", window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      } else {
+        document.documentElement.setAttribute("data-theme", t);
+      }
+    };
+    apply(theme);
+    if (theme === "system") {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
-      const handler = (e: MediaQueryListEvent) => {
-        document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
-      };
+      const handler = (e: MediaQueryListEvent) => document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
       mq.addEventListener("change", handler);
       return () => mq.removeEventListener("change", handler);
     }
   }, [editorSettings.colorTheme]);
 
+  // --- Auto backup every 10 min ---
   useEffect(() => {
     if (!loaded) return;
     const timer = setInterval(() => {
-      const { scenes: sc, manuscripts: ms } = latestStateRef.current;
-      const newAutoBackup: Backup = { timestamp: new Date().toISOString(), label: null, scenes: sc, manuscripts: ms, settings, projectTitle };
-      setAutoBackups(prev => [newAutoBackup, ...prev].slice(0, 5));
+      const s = useStudioStore.getState();
+      const entry: Backup = { timestamp: new Date().toISOString(), label: null, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, projectTitle: s.projectTitle };
+      store.setAutoBackups(prev => [entry, ...prev].slice(0, 5));
     }, 10 * 60 * 1000);
     return () => clearInterval(timer);
-  }, [loaded, settings, projectTitle]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
 
-  const handleSceneSelect = (scene: Scene) => { setSelectedSceneId(scene.id); setTab("write"); };
-  const handleManuscriptChange = (text: string) => setManuscripts(prev => ({ ...prev, [selectedSceneId as number]: text }));
-  const handleStatusChange = (id: number, status: SceneStatus) => setScenes(scenes.map(s => s.id === id ? { ...s, status } : s));
-  const handleAddScene = () => {
-    const scene: Scene = { ...newScene, id: Date.now(), status: "empty" };
-    setScenes([...scenes, scene]);
-    setNewScene({ chapter: "", title: "", synopsis: "" });
-    setAddingScene(false);
-  };
-  const handleDeleteScene = (id: number) => setConfirmDelete(id);
-  const confirmDeleteExecute = () => {
-    const id = confirmDelete;
-    if (id === null) return;
-    setScenes(prev => prev.filter(s => s.id !== id));
-    if (selectedSceneId === id) setSelectedSceneId(null);
-    setManuscripts(prev => { const n = { ...prev }; delete n[id]; return n; });
-    setConfirmDelete(null);
-  };
-
-  const downloadFile = (content: string, filename: string) => {
-    const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
-    const blob = new Blob([bom, content], { type: "text/plain;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    alert(`${filename} を出力しました。`);
-  };
-
-  const exportScene = (fmt: "md" | "txt") => {
-    if (!selectedScene) return;
-    const text = manuscripts[selectedScene.id] || "";
-    const content = fmt === "md"
-      ? `# ${selectedScene.chapter} — ${selectedScene.title}\n\n${selectedScene.synopsis ? `> ${selectedScene.synopsis}\n\n` : ""}${text}`
-      : `${selectedScene.chapter} — ${selectedScene.title}\n${"=".repeat(30)}\n${selectedScene.synopsis ? `${selectedScene.synopsis}\n\n` : ""}${text}`;
-    downloadFile(content, `${selectedScene.title}.${fmt}`);
-    setShowExport(false);
-  };
-
-  const exportAll = (fmt: "md" | "txt") => {
-    const content = fmt === "md"
-      ? `# ${projectTitle}\n\n` + scenes.map(s => `## ${s.chapter} — ${s.title}\n\n${s.synopsis ? `> ${s.synopsis}\n\n` : ""}${manuscripts[s.id] || "（未執筆）"}`).join("\n\n---\n\n")
-      : scenes.map(s => `${s.chapter} — ${s.title}\n${"=".repeat(30)}\n${s.synopsis ? `${s.synopsis}\n\n` : ""}${manuscripts[s.id] || "（未執筆）"}`).join("\n\n" + "─".repeat(40) + "\n\n");
-    downloadFile(content, `${projectTitle}.${fmt}`);
-    setShowExport(false);
-  };
-
-  const handleSaveBackup = (label: string | null) => {
-    const newBackup = {
-      timestamp: new Date().toISOString(),
-      label,
-      scenes,
-      manuscripts,
-      settings,
-      projectTitle,
-    };
-    const updated = [newBackup, ...backups].slice(0, 5);
-    setBackups(updated);
-    storageSet("minato:backups", updated);
-  };
-
-  const value: StudioContextType = {
-    loaded, saveStatus, lastSavedTime, tab, setTab, settings, setSettings,
-    settingsTab, setSettingsTab, scenes, setScenes, selectedSceneId, setSelectedSceneId,
-    manuscripts, setManuscripts, showSettings, setShowSettings, sidebarOpen, setSidebarOpen,
-    newScene, setNewScene, addingScene, setAddingScene, confirmDelete, setConfirmDelete,
-    addingChapter, setAddingChapter, projectTitle, setProjectTitle, editingTitle, setEditingTitle,
-    showExport, setShowExport, sceneSearch, setSceneSearch, backups, setBackups,
-    showBackups, setShowBackups, verticalPreview, setVerticalPreview,
-    editingSceneTitle, setEditingSceneTitle, editingSceneSynopsis, setEditingSceneSynopsis,
-    sidebarFloat, setSidebarFloat, sidebarTab, setSidebarTab, editorSettings, setEditorSettings,
-    aiFloat, setAiFloat, aiWide, setAiWide, aiResults, setAiResults, aiErrors, setAiErrors, aiLoading, setAiLoading,
-    aiApplied, setAiApplied, hintApplied, setHintApplied,
-    aiHistory, addAiHistory, clearAiHistory, autoBackups,
-    selectedScene, manuscriptText, wordCount,
-    handleSceneSelect, handleManuscriptChange, handleStatusChange, handleAddScene,
-    handleDeleteScene, confirmDeleteExecute, saveWithBackup, exportScene, exportAll,
-    handleSaveBackup
-  };
-
-  return <StudioContext.Provider value={value}>{children}</StudioContext.Provider>;
+  return <>{children}</>;
 }
 
-export function useStudio() {
-  const context = useContext(StudioContext);
-  if (context === undefined) {
-    throw new Error("useStudio must be used within a StudioProvider");
-  }
-  return context;
-}
+// ---------------------------------------------------------------------------
+// useStudio — drop-in replacement for the old context hook
+// ---------------------------------------------------------------------------
+
+export { useStudioStore as useStudio };

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -1,0 +1,416 @@
+import { create } from "zustand";
+import type {
+  SceneStatus, Scene, Settings, Manuscripts, AppliedState,
+  AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem
+} from "../types";
+import { initialSettings, initialScenes } from "../constants";
+import { storageSet } from "../utils/storage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeDerived(
+  scenes: Scene[],
+  manuscripts: Manuscripts,
+  selectedSceneId: number | null
+) {
+  const selectedScene = scenes.find(s => s.id === selectedSceneId) ?? null;
+  const manuscriptText = selectedSceneId ? (manuscripts[selectedSceneId] ?? "") : "";
+  const wordCount = manuscriptText.replace(/\s/g, "").length;
+  return { selectedScene, manuscriptText, wordCount };
+}
+
+// ---------------------------------------------------------------------------
+// State interface
+// ---------------------------------------------------------------------------
+
+export interface StudioState {
+  // persistence / loading
+  loaded: boolean;
+  saveStatus: SaveStatus;
+  lastSavedTime: Date | null;
+
+  // navigation
+  tab: TabKey;
+  sidebarTab: SidebarTabKey;
+  settingsTab: keyof Settings;
+
+  // core data
+  scenes: Scene[];
+  selectedSceneId: number | null;
+  manuscripts: Manuscripts;
+  settings: Settings;
+  projectTitle: string;
+
+  // sidebar UI
+  sidebarOpen: boolean;
+  sidebarFloat: boolean;
+
+  // scene editing
+  newScene: SceneDraft;
+  addingScene: boolean;
+  addingChapter: boolean;
+  confirmDelete: number | null;
+  sceneSearch: string;
+  editingSceneTitle: boolean;
+  editingSceneSynopsis: boolean;
+
+  // other UI
+  showSettings: boolean;
+  editingTitle: boolean;
+  showExport: boolean;
+  showBackups: boolean;
+  verticalPreview: boolean;
+
+  // editor
+  editorSettings: EditorSettings;
+
+  // backup
+  backups: Backup[];
+  autoBackups: Backup[];
+
+  // AI
+  aiFloat: boolean;
+  aiWide: boolean;
+  aiResults: AiResults;
+  aiErrors: AiErrors;
+  aiLoading: AiLoading;
+  aiApplied: AppliedState;
+  hintApplied: AppliedState;
+  aiHistory: AiHistoryItem[];
+
+  // derived (kept in store for fast access)
+  selectedScene: Scene | null;
+  manuscriptText: string;
+  wordCount: number;
+
+  // ---------------------------------------------------------------------------
+  // Setters (plain state updates)
+  // ---------------------------------------------------------------------------
+  setLoaded: (v: boolean) => void;
+  setSaveStatus: (v: SaveStatus) => void;
+  setLastSavedTime: (v: Date | null) => void;
+  setTab: (v: TabKey) => void;
+  setSidebarTab: (v: SidebarTabKey) => void;
+  setSettingsTab: (v: keyof Settings) => void;
+  setScenes: (v: Scene[] | ((prev: Scene[]) => Scene[])) => void;
+  setSelectedSceneId: (v: number | null) => void;
+  setManuscripts: (v: Manuscripts | ((prev: Manuscripts) => Manuscripts)) => void;
+  setSettings: (v: Settings | ((prev: Settings) => Settings)) => void;
+  setProjectTitle: (v: string) => void;
+  setSidebarOpen: (v: boolean) => void;
+  setSidebarFloat: (v: boolean) => void;
+  setNewScene: (v: SceneDraft) => void;
+  setAddingScene: (v: boolean) => void;
+  setAddingChapter: (v: boolean) => void;
+  setConfirmDelete: (v: number | null) => void;
+  setSceneSearch: (v: string) => void;
+  setEditingSceneTitle: (v: boolean) => void;
+  setEditingSceneSynopsis: (v: boolean) => void;
+  setShowSettings: (v: boolean) => void;
+  setEditingTitle: (v: boolean) => void;
+  setShowExport: (v: boolean) => void;
+  setShowBackups: (v: boolean) => void;
+  setVerticalPreview: (v: boolean) => void;
+  setEditorSettings: (v: EditorSettings | ((prev: EditorSettings) => EditorSettings)) => void;
+  setBackups: (v: Backup[] | ((prev: Backup[]) => Backup[])) => void;
+  setAutoBackups: (v: Backup[] | ((prev: Backup[]) => Backup[])) => void;
+  setAiFloat: (v: boolean) => void;
+  setAiWide: (v: boolean) => void;
+  setAiResults: (v: AiResults | ((prev: AiResults) => AiResults)) => void;
+  setAiErrors: (v: AiErrors | ((prev: AiErrors) => AiErrors)) => void;
+  setAiLoading: (v: AiLoading | ((prev: AiLoading) => AiLoading)) => void;
+  setAiApplied: (v: AppliedState | ((prev: AppliedState) => AppliedState)) => void;
+  setHintApplied: (v: AppliedState | ((prev: AppliedState) => AppliedState)) => void;
+  setAiHistory: (v: AiHistoryItem[] | ((prev: AiHistoryItem[]) => AiHistoryItem[])) => void;
+
+  // ---------------------------------------------------------------------------
+  // Actions (business logic)
+  // ---------------------------------------------------------------------------
+  addAiHistory: (label: string, content: string, sceneTitle?: string) => void;
+  clearAiHistory: () => void;
+  handleSceneSelect: (scene: Scene) => void;
+  handleManuscriptChange: (text: string) => void;
+  handleStatusChange: (id: number, status: SceneStatus) => void;
+  handleAddScene: () => void;
+  handleDeleteScene: (id: number) => void;
+  confirmDeleteExecute: () => void;
+  saveWithBackup: (sc: Scene[], st: Settings, ms: Manuscripts, pt: string, label?: string | null) => Promise<void>;
+  handleSaveBackup: (label: string | null) => void;
+  exportScene: (fmt: "md" | "txt") => void;
+  exportAll: (fmt: "md" | "txt") => void;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const aiResultsInit: AiResults = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" };
+const aiErrorsInit: AiErrors = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" };
+const aiLoadingInit: AiLoading = { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false };
+
+function downloadFile(content: string, filename: string) {
+  const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
+  const blob = new Blob([bom, content], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  alert(`${filename} を出力しました。`);
+}
+
+export const useStudioStore = create<StudioState>((set, get) => ({
+  // Initial state
+  loaded: false,
+  saveStatus: "saved",
+  lastSavedTime: null,
+  tab: "write",
+  sidebarTab: "write",
+  settingsTab: "world",
+  scenes: initialScenes,
+  selectedSceneId: null,
+  manuscripts: {},
+  settings: initialSettings,
+  projectTitle: "港に届いた例外",
+  sidebarOpen: true,
+  sidebarFloat: true,
+  newScene: { chapter: "", title: "", synopsis: "" },
+  addingScene: false,
+  addingChapter: false,
+  confirmDelete: null,
+  sceneSearch: "",
+  editingSceneTitle: false,
+  editingSceneSynopsis: false,
+  showSettings: false,
+  editingTitle: false,
+  showExport: false,
+  showBackups: false,
+  verticalPreview: false,
+  editorSettings: { fontSize: 15, lineHeight: 2.2, colorTheme: "dark" },
+  backups: [],
+  autoBackups: [],
+  aiFloat: false,
+  aiWide: false,
+  aiResults: aiResultsInit,
+  aiErrors: aiErrorsInit,
+  aiLoading: aiLoadingInit,
+  aiApplied: {},
+  hintApplied: {},
+  aiHistory: [],
+  selectedScene: null,
+  manuscriptText: "",
+  wordCount: 0,
+
+  // ---------------------------------------------------------------------------
+  // Setters
+  // ---------------------------------------------------------------------------
+  setLoaded: (v) => set({ loaded: v }),
+  setSaveStatus: (v) => set({ saveStatus: v }),
+  setLastSavedTime: (v) => set({ lastSavedTime: v }),
+  setTab: (v) => set({ tab: v }),
+  setSidebarTab: (v) => set({ sidebarTab: v }),
+  setSettingsTab: (v) => set({ settingsTab: v }),
+  setScenes: (v) => set((s) => {
+    const next = typeof v === "function" ? v(s.scenes) : v;
+    return { scenes: next, ...computeDerived(next, s.manuscripts, s.selectedSceneId) };
+  }),
+  setSelectedSceneId: (v) => set((s) => ({
+    selectedSceneId: v,
+    ...computeDerived(s.scenes, s.manuscripts, v),
+  })),
+  setManuscripts: (v) => set((s) => {
+    const next = typeof v === "function" ? v(s.manuscripts) : v;
+    return { manuscripts: next, ...computeDerived(s.scenes, next, s.selectedSceneId) };
+  }),
+  setSettings: (v) => set((s) => ({ settings: typeof v === "function" ? v(s.settings) : v })),
+  setProjectTitle: (v) => set({ projectTitle: v }),
+  setSidebarOpen: (v) => set({ sidebarOpen: v }),
+  setSidebarFloat: (v) => set({ sidebarFloat: v }),
+  setNewScene: (v) => set({ newScene: v }),
+  setAddingScene: (v) => set({ addingScene: v }),
+  setAddingChapter: (v) => set({ addingChapter: v }),
+  setConfirmDelete: (v) => set({ confirmDelete: v }),
+  setSceneSearch: (v) => set({ sceneSearch: v }),
+  setEditingSceneTitle: (v) => set({ editingSceneTitle: v }),
+  setEditingSceneSynopsis: (v) => set({ editingSceneSynopsis: v }),
+  setShowSettings: (v) => set({ showSettings: v }),
+  setEditingTitle: (v) => set({ editingTitle: v }),
+  setShowExport: (v) => set({ showExport: v }),
+  setShowBackups: (v) => set({ showBackups: v }),
+  setVerticalPreview: (v) => set({ verticalPreview: v }),
+  setEditorSettings: (v) => set((s) => ({ editorSettings: typeof v === "function" ? v(s.editorSettings) : v })),
+  setBackups: (v) => set((s) => ({ backups: typeof v === "function" ? v(s.backups) : v })),
+  setAutoBackups: (v) => set((s) => ({ autoBackups: typeof v === "function" ? v(s.autoBackups) : v })),
+  setAiFloat: (v) => set({ aiFloat: v }),
+  setAiWide: (v) => set({ aiWide: v }),
+  setAiResults: (v) => set((s) => ({ aiResults: typeof v === "function" ? v(s.aiResults) : v })),
+  setAiErrors: (v) => set((s) => ({ aiErrors: typeof v === "function" ? v(s.aiErrors) : v })),
+  setAiLoading: (v) => set((s) => ({ aiLoading: typeof v === "function" ? v(s.aiLoading) : v })),
+  setAiApplied: (v) => set((s) => ({ aiApplied: typeof v === "function" ? v(s.aiApplied) : v })),
+  setHintApplied: (v) => set((s) => ({ hintApplied: typeof v === "function" ? v(s.hintApplied) : v })),
+  setAiHistory: (v) => set((s) => ({ aiHistory: typeof v === "function" ? v(s.aiHistory) : v })),
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+  addAiHistory: (label, content, sceneTitle) => {
+    if (!content.trim()) return;
+    const item: AiHistoryItem = { id: Date.now(), timestamp: new Date().toISOString(), label, content, sceneTitle };
+    set(s => ({ aiHistory: [item, ...s.aiHistory].slice(0, 30) }));
+  },
+
+  clearAiHistory: () => {
+    set({ aiHistory: [] });
+    storageSet("minato:aiHistory", []);
+  },
+
+  handleSceneSelect: (scene) => set((s) => ({
+    selectedSceneId: scene.id,
+    tab: "write",
+    ...computeDerived(s.scenes, s.manuscripts, scene.id),
+  })),
+
+  handleManuscriptChange: (text) => {
+    const { selectedSceneId, manuscripts, scenes } = get();
+    if (selectedSceneId === null) return;
+    const next = { ...manuscripts, [selectedSceneId]: text };
+    set({ manuscripts: next, ...computeDerived(scenes, next, selectedSceneId) });
+  },
+
+  handleStatusChange: (id, status) => set((s) => {
+    const next = s.scenes.map(sc => sc.id === id ? { ...sc, status } : sc);
+    return { scenes: next, ...computeDerived(next, s.manuscripts, s.selectedSceneId) };
+  }),
+
+  handleAddScene: () => set((s) => {
+    const scene: Scene = { ...s.newScene, id: Date.now(), status: "empty" };
+    const next = [...s.scenes, scene];
+    return {
+      scenes: next,
+      newScene: { chapter: "", title: "", synopsis: "" },
+      addingScene: false,
+      ...computeDerived(next, s.manuscripts, s.selectedSceneId),
+    };
+  }),
+
+  handleDeleteScene: (id) => set({ confirmDelete: id }),
+
+  confirmDeleteExecute: () => set((s) => {
+    if (s.confirmDelete === null) return {};
+    const id = s.confirmDelete;
+    const nextScenes = s.scenes.filter(sc => sc.id !== id);
+    const nextManuscripts = { ...s.manuscripts };
+    delete nextManuscripts[id];
+    const nextSelectedId = s.selectedSceneId === id ? null : s.selectedSceneId;
+    return {
+      scenes: nextScenes,
+      manuscripts: nextManuscripts,
+      selectedSceneId: nextSelectedId,
+      confirmDelete: null,
+      ...computeDerived(nextScenes, nextManuscripts, nextSelectedId),
+    };
+  }),
+
+  saveWithBackup: async (sc, st, ms, pt, label = null) => {
+    set({ saveStatus: "saving" });
+    const { backups } = get();
+    try {
+      const newBackup = { timestamp: new Date().toISOString(), label, scenes: sc, manuscripts: ms, settings: st, projectTitle: pt };
+      const updatedBackups = [newBackup, ...backups].slice(0, 5);
+      set({ backups: updatedBackups });
+      const results = await Promise.all([
+        storageSet("minato:scenes", sc),
+        storageSet("minato:settings", st),
+        storageSet("minato:manuscripts", ms),
+        storageSet("minato:title", pt),
+        storageSet("minato:backups", updatedBackups),
+      ]);
+      if (results.every(r => r)) {
+        set({ saveStatus: "saved", lastSavedTime: new Date() });
+      } else {
+        set({ saveStatus: navigator.onLine ? "error" : "offline" });
+      }
+    } catch {
+      set({ saveStatus: "error" });
+    }
+  },
+
+  handleSaveBackup: (label) => {
+    const { backups, scenes, manuscripts, settings, projectTitle } = get();
+    const newBackup = { timestamp: new Date().toISOString(), label, scenes, manuscripts, settings, projectTitle };
+    const updated = [newBackup, ...backups].slice(0, 5);
+    set({ backups: updated });
+    storageSet("minato:backups", updated);
+  },
+
+  exportScene: (fmt) => {
+    const { scenes, selectedSceneId, manuscripts } = get();
+    const scene = scenes.find(s => s.id === selectedSceneId);
+    if (!scene) return;
+    const text = manuscripts[scene.id] || "";
+    const content = fmt === "md"
+      ? `# ${scene.chapter} — ${scene.title}\n\n${scene.synopsis ? `> ${scene.synopsis}\n\n` : ""}${text}`
+      : `${scene.chapter} — ${scene.title}\n${"=".repeat(30)}\n${scene.synopsis ? `${scene.synopsis}\n\n` : ""}${text}`;
+    downloadFile(content, `${scene.title}.${fmt}`);
+    set({ showExport: false });
+  },
+
+  exportAll: (fmt) => {
+    const { projectTitle, scenes, manuscripts } = get();
+    const content = fmt === "md"
+      ? `# ${projectTitle}\n\n` + scenes.map(s => `## ${s.chapter} — ${s.title}\n\n${s.synopsis ? `> ${s.synopsis}\n\n` : ""}${manuscripts[s.id] || "（未執筆）"}`).join("\n\n---\n\n")
+      : scenes.map(s => `${s.chapter} — ${s.title}\n${"=".repeat(30)}\n${s.synopsis ? `${s.synopsis}\n\n` : ""}${manuscripts[s.id] || "（未執筆）"}`).join("\n\n" + "─".repeat(40) + "\n\n");
+    downloadFile(content, `${projectTitle}.${fmt}`);
+    set({ showExport: false });
+  },
+}));
+
+// テスト用: ストアを初期状態にリセットする
+export function resetStudioStore() {
+  useStudioStore.setState({
+    loaded: false,
+    saveStatus: "saved",
+    lastSavedTime: null,
+    tab: "write",
+    sidebarTab: "write",
+    settingsTab: "world",
+    scenes: initialScenes,
+    selectedSceneId: null,
+    manuscripts: {},
+    settings: initialSettings,
+    projectTitle: "港に届いた例外",
+    sidebarOpen: true,
+    sidebarFloat: true,
+    newScene: { chapter: "", title: "", synopsis: "" },
+    addingScene: false,
+    addingChapter: false,
+    confirmDelete: null,
+    sceneSearch: "",
+    editingSceneTitle: false,
+    editingSceneSynopsis: false,
+    showSettings: false,
+    editingTitle: false,
+    showExport: false,
+    showBackups: false,
+    verticalPreview: false,
+    editorSettings: { fontSize: 15, lineHeight: 2.2, colorTheme: "dark" },
+    backups: [],
+    autoBackups: [],
+    aiFloat: false,
+    aiWide: false,
+    aiResults: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" },
+    aiErrors: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" },
+    aiLoading: { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false },
+    aiApplied: {},
+    hintApplied: {},
+    aiHistory: [],
+    selectedScene: null,
+    manuscriptText: "",
+    wordCount: 0,
+  });
+}


### PR DESCRIPTION
- zustand v5 をインストール
- src/stores/useStudioStore.ts を新規作成
  - StudioContext の全ステート・アクションを zustand store に移動
  - computeDerived() でselectedScene / manuscriptText / wordCountをset時に同期計算
  - resetStudioStore() をテスト用にエクスポート
- StudioContext.tsx をラッパーに置き換え
  - StudioProvider: データロード・自動保存・テーマ・オフライン同期の副作用のみ担当
  - useStudio() は useStudioStore() を再エクスポート（既存コンポーネント無変更）
- StudioContext.test.tsx: beforeEach/afterEach で resetStudioStore() を呼び出し ストア状態がテスト間で汚染されないよう修正 (全11テストパス)

テスト: 60/60 パス (AiAssistant.test.ts の Supabase エラーは既存の問題)

https://claude.ai/code/session_01E5SSpHvTVKQAMNHkN9G4GL