### PR TITLE
fix(test): テスト環境にダミーSupabase URL を設定、zustand をインストール

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,9 @@ export default defineConfig({
     globals: true,
     setupFiles: "./vitest.setup.ts",
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    env: {
+      VITE_SUPABASE_URL: "http://localhost:54321",
+      VITE_SUPABASE_ANON_KEY: "test-anon-key",
+    },
   },
 });


### PR DESCRIPTION
- vitest.config.ts に VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY のダミー値を追加
- zustand が node_modules に存在しなかったため npm install zustand を実行

https://claude.ai/code/session_01E5SSpHvTVKQAMNHkN9G4GL