### PR TITLE
fix: rawText 未使用変数削除・build:wasm で .gitignore を自動削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build:wasm": "wasm-pack build rust/text-analyzer --target bundler --out-dir ../../src/wasm/text_analyzer",
+    "build:wasm": "wasm-pack build rust/text-analyzer --target bundler --out-dir ../../src/wasm/text_analyzer && rm -f src/wasm/text_analyzer/.gitignore",
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",

--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -40,7 +40,6 @@ export function ImportModal() {
   const [sections, setSections] = useState<ParsedSection[]>([]);
   const [characters, setCharacters] = useState("");
   const [world, setWorld] = useState("");
-  const [rawText, setRawText] = useState("");
 
   const handleFile = useCallback(async (file: File) => {
     if (!file.name.match(/\.(md|txt)$/i)) {
@@ -51,7 +50,6 @@ export function ImportModal() {
     setStep("analyzing");
 
     const text = await file.text();
-    setRawText(text);
 
     const [parsed, aiResult] = await Promise.all([
       parseDocument(text),


### PR DESCRIPTION
- ImportModal.tsx: rawText state は未使用だったため削除
- package.json: build:wasm 後に wasm-pack が生成する .gitignore を rm -f で除去 （再ビルド時に WASM アーティファクトが誤って gitignore されるのを防ぐ）

https://claude.ai/code/session_01E5SSpHvTVKQAMNHkN9G4GL