### PR TITLE
fix: バグ3件を修正 (YUY-30/YUY-37/YUY-32)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,7 +121,7 @@ function Studio() {
                       onClick={() => setShowCurrentOnly(v => !v)}
                       style={{ fontSize: "11px", padding: "4px 12px", background: showCurrentOnly ? "rgba(74,111,165,0.2)" : "transparent", border: `1px solid ${showCurrentOnly ? "#4a6fa5" : "#1e2d42"}`, color: showCurrentOnly ? "#7ab3e0" : "#3a5570", borderRadius: "4px", cursor: "pointer", fontFamily: "inherit" }}
                     >
-                      {showCurrentOnly ? "全て表示" : "現在のシーンのみ"}
+                      {showCurrentOnly ? "現在のシーンのみ" : "全て表示"}
                     </button>
                   )}
                   {aiHistory.length > 0 && (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -372,7 +372,7 @@ export const Sidebar: React.FC = () => {
                     onClick={() => setShowCurrentOnly(v => !v)}
                     style={{ fontSize: 9, padding: "2px 7px", background: showCurrentOnly ? "rgba(74,111,165,0.2)" : "transparent", border: `1px solid ${showCurrentOnly ? "#4a6fa5" : "#1e2d42"}`, color: showCurrentOnly ? "#7ab3e0" : "#2a4060", borderRadius: 3, cursor: "pointer", fontFamily: "inherit" }}
                   >
-                    {showCurrentOnly ? "全表示" : "現在"}
+                    {showCurrentOnly ? "現在" : "全表示"}
                   </button>
                 )}
                 {aiHistory.length > 0 && (

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -20,20 +20,28 @@ export const SettingsView: React.FC = () => {
         ))}
       </div>
       <textarea value={settings[settingsTab]} onChange={e => setSettings({ ...settings, [settingsTab]: e.target.value })} style={{ width: "100%", minHeight: 280, background: "#070a14", border: "1px solid #1a2535", color: "#8ab0cc", fontFamily: "'Noto Serif JP','Georgia',serif", fontSize: 13, lineHeight: 2, padding: "20px 24px", resize: "vertical", outline: "none", borderRadius: 6, boxSizing: "border-box" }} />
-      <AiPanel
-        label="AIで意味を拡張"
-        result={aiResults.worldExpand || ""}
-        onResult={t => {
-          setAiResults(r => ({ ...r, worldExpand: t }));
-          if (t) addAiHistory("世界観拡張", t);
-        }}
-        onLoading={v => setAiLoading(l => ({ ...l, worldExpand: v }))}
-        loading={aiLoading.worldExpand}
-        error={aiErrors.worldExpand}
-        onError={t => setAiErrors(e => ({ ...e, worldExpand: t }))}
-        prompt={`以下の創作設定メモを読んで、含意・伏線の可能性・派生しうる要素・見落とされがちな矛盾を簡潔に指摘してください。箇条書きで3〜5点。\n\n【${settingsTab === "world" ? "世界観" : settingsTab === "characters" ? "キャラクター" : "テーマ"}】\n${settings[settingsTab]}`}
-        onAppend={text => setSettings(prev => ({ ...prev, [settingsTab]: prev[settingsTab] + "\n\n---AI拡張---\n" + text }))}
-      />
+      {(() => {
+        const tabKeyMap = { world: "worldExpand", characters: "characterExpand", theme: "themeExpand" } as const;
+        const tabLabelMap = { world: "世界観", characters: "キャラクター", theme: "テーマ" } as const;
+        const resultKey = tabKeyMap[settingsTab];
+        const tabLabel = tabLabelMap[settingsTab];
+        return (
+          <AiPanel
+            label="AIで意味を拡張"
+            result={aiResults[resultKey] || ""}
+            onResult={t => {
+              setAiResults(r => ({ ...r, [resultKey]: t }));
+              if (t) addAiHistory(`${tabLabel}拡張`, t);
+            }}
+            onLoading={v => setAiLoading(l => ({ ...l, [resultKey]: v }))}
+            loading={aiLoading[resultKey]}
+            error={aiErrors[resultKey]}
+            onError={t => setAiErrors(e => ({ ...e, [resultKey]: t }))}
+            prompt={`以下の創作設定メモを読んで、含意・伏線の可能性・派生しうる要素・見落とされがちな矛盾を簡潔に指摘してください。箇条書きで3〜5点。\n\n【${tabLabel}】\n${settings[settingsTab]}`}
+            onAppend={text => setSettings(prev => ({ ...prev, [settingsTab]: prev[settingsTab] + "\n\n---AI拡張---\n" + text }))}
+          />
+        );
+      })()}
     </div>
   );
 };

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -20,6 +20,7 @@ import { analyzeText } from "../utils/textAnalyzer";
 export function StudioProvider({ children, user }: { children: React.ReactNode; user: User }) {
   const store = useStudioStore();
   const syncAllRef = useRef<() => Promise<void>>(async () => {});
+  const skipInitialSaveRef = useRef(true);
 
   // --- Initial load ---
   useEffect(() => {
@@ -57,6 +58,10 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
 
   useEffect(() => {
     if (!loaded) return;
+    if (skipInitialSaveRef.current) {
+      skipInitialSaveRef.current = false;
+      return;
+    }
     const syncAll = async () => {
       store.setSaveStatus("saving");
       try {

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -151,9 +151,9 @@ export interface StudioState {
 // Store
 // ---------------------------------------------------------------------------
 
-const aiResultsInit: AiResults = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" };
-const aiErrorsInit: AiErrors = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" };
-const aiLoadingInit: AiLoading = { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false };
+const aiResultsInit: AiResults = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" };
+const aiErrorsInit: AiErrors = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" };
+const aiLoadingInit: AiLoading = { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false };
 
 function downloadFile(content: string, filename: string) {
   const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
@@ -456,9 +456,9 @@ export function resetStudioStore() {
     autoBackups: [],
     aiFloat: false,
     aiWide: false,
-    aiResults: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" },
-    aiErrors: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", freeInstruct: "" },
-    aiLoading: { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, freeInstruct: false },
+    aiResults: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" },
+    aiErrors: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" },
+    aiLoading: { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false },
     aiApplied: {},
     hintApplied: {},
     aiHistory: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export type AiResults = {
   continue: string;
   synopsis: string;
   worldExpand: string;
+  characterExpand: string;
+  themeExpand: string;
   freeInstruct: string;
 };
 


### PR DESCRIPTION
## Summary

- **YUY-30** AI履歴フィルターボタンのテキストが逆になっていた問題を修正
  - `showCurrentOnly=true` のとき「現在のシーンのみ」、`false` のとき「全て表示」を表示するよう修正（App.tsx / Sidebar.tsx）
- **YUY-37** 起動時に「保存中…」が表示される問題を修正
  - `StudioContext.tsx` に `skipInitialSaveRef` を追加し、初期ロード完了直後の自動保存をスキップ
- **YUY-32** 世界観タブのAI生成がタブをまたいで同じ結果キーを使っていた問題を修正
  - `characterExpand` / `themeExpand` キーを `AiResults` 型に追加
  - `SettingsView.tsx` でタブごとに独立したキーを使用するよう変更

## Test plan

- [ ] AI履歴タブで「全て表示」ボタンが全件表示中に、「現在のシーンのみ」ボタンが現在シーンのみ表示中に正しく表示されることを確認
- [ ] アプリ起動直後に「保存中…」が表示されないことを確認
- [ ] 世界観タブでAI生成後にキャラクタータブ・テーマタブに切り替えると結果がリセットされることを確認（タブ独立）

🤖 Generated with [Claude Code](https://claude.com/claude-code)