### PR TITLE
fix: 世界観AI履歴「追記」の追記先を世界観メモに修正 (YUY-33)

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -31,6 +31,14 @@ export const Sidebar: React.FC = () => {
 
   // YUY-27: 追記先シーンへ移動してから追記する（表示シーン以外にも正しく適用）
   const onInsertHistory = (item: AiHistoryItem) => {
+    if (item.label === "世界観拡張") {
+      setSettings(prev => ({
+        ...prev,
+        world: prev.world + (prev.world ? "\n" : "") + item.content,
+      }));
+      return;
+    }
+
     if (item.sceneId && item.sceneId !== selectedSceneId) {
       const targetScene = scenes.find(s => s.id === item.sceneId);
       if (targetScene) {


### PR DESCRIPTION
### Motivation
- `世界観拡張` として生成された AI 履歴を本文ではなく世界観メモ（`settings.world`）に追記する必要があったため。

### Description
- `src/components/layout/Sidebar.tsx` の `onInsertHistory` に分岐を追加し、`item.label === "世界観拡張"` の場合は `settings.world` を更新して履歴内容を追記するようにしました。 

### Testing
- `npm run test:run`（`vitest`）を実行し、全テストが成功（62 件のテストがすべてパス）することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5222ae3d4832399affc053dabfae6)