### PR TITLE
feat: add bookshelf icon + project shelf modal and local project library

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { PrefsView } from "./components/views/PrefsView";
 import { BackupModal } from "./components/modals/BackupModal";
 import { ExportModal } from "./components/modals/ExportModal";
 import { ImportModal } from "./components/modals/ImportModal";
+import { ProjectShelfModal } from "./components/modals/ProjectShelfModal";
 import { DeleteConfirmModal } from "./components/modals/DeleteConfirmModal";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { StudioProvider, useStudio } from "./contexts/StudioContext";
@@ -73,7 +74,7 @@ export default function App() {
 function Studio() {
   const {
     loaded, tab, sidebarOpen, showSettings,
-    confirmDelete, showExport, showBackups, showImport, setSidebarOpen, setShowSettings,
+    confirmDelete, showExport, showBackups, showImport, showProjectShelf, setSidebarOpen, setShowSettings,
     sidebarFloat, aiHistory, clearAiHistory, manuscriptText, handleManuscriptChange,
     scenes, selectedSceneId, handleSceneSelect, manuscripts, setTab,
   } = useStudio();
@@ -96,6 +97,8 @@ function Studio() {
       {showImport && <ImportModal />}
       {/* Backup modal */}
       {showBackups && <BackupModal />}
+      {/* Project shelf */}
+      {showProjectShelf && <ProjectShelfModal />}
       <Header />
 
       <div style={{ display: "flex", flex: 1, minHeight: 0, position: "relative" }}>

--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -31,7 +31,9 @@ describe("Header", () => {
       manuscripts: {},
       saveWithBackup: vi.fn(),
       setShowBackups: vi.fn(),
+      setShowImport: vi.fn(),
       setShowExport: vi.fn(),
+      setShowProjectShelf: vi.fn(),
     });
 
     render(<Header />);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ export const Header: React.FC = () => {
   const {
     projectTitle, setProjectTitle, editingTitle, setEditingTitle,
     saveStatus, lastSavedTime, scenes, settings, manuscripts,
-    saveWithBackup, setShowBackups, setShowExport, setShowImport
+    saveWithBackup, setShowBackups, setShowExport, setShowImport, setShowProjectShelf
   } = useStudio();
   const hasProjectTitle = projectTitle.trim().length > 0;
 
@@ -14,18 +14,20 @@ export const Header: React.FC = () => {
     <header style={{ borderBottom: "1px solid #1e2d42", padding: "0 16px", display: "flex", alignItems: "center", justifyContent: "space-between", background: "rgba(10,14,26,0.95)", position: "sticky", top: 0, zIndex: 100, height: 44 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
         {/* アイコン */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, flexShrink: 0 }}>
+        <button
+          onClick={() => setShowProjectShelf(true)}
+          title="本棚を開く"
+          style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, flexShrink: 0, border: "none", background: "transparent", padding: 0, cursor: "pointer" }}
+        >
           <svg width="24" height="24" viewBox="0 0 28 28" fill="none">
-            <rect x="4" y="4" width="20" height="20" rx="2" stroke="#1e3050" strokeWidth="1.5"/>
-            <line x1="8" y1="9" x2="20" y2="9" stroke="#2a4060" strokeWidth="1.2"/>
-            <line x1="8" y1="13" x2="20" y2="13" stroke="#2a4060" strokeWidth="1.2"/>
-            <line x1="8" y1="17" x2="16" y2="17" stroke="#1e3050" strokeWidth="1.2"/>
-            <circle cx="22" cy="22" r="5" fill="#0a0e1a" stroke="#4a6fa5" strokeWidth="1"/>
-            <line x1="20" y1="22" x2="24" y2="22" stroke="#4a6fa5" strokeWidth="1"/>
-            <line x1="22" y1="20" x2="22" y2="24" stroke="#4a6fa5" strokeWidth="1"/>
+            <rect x="4.5" y="4.5" width="4" height="19" rx="0.8" stroke="#4a6fa5" strokeWidth="1.2"/>
+            <rect x="9.8" y="5.4" width="3.6" height="18.1" rx="0.8" stroke="#3d5d8b" strokeWidth="1.2"/>
+            <rect x="14.4" y="4.1" width="4.4" height="19.4" rx="0.8" stroke="#5f7fae" strokeWidth="1.2"/>
+            <rect x="19.8" y="6" width="3.7" height="17.5" rx="0.8" stroke="#2f4a70" strokeWidth="1.2"/>
+            <line x1="3.5" y1="23.5" x2="24.5" y2="23.5" stroke="#1e3050" strokeWidth="1.2"/>
           </svg>
           <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textTransform: "lowercase", whiteSpace: "nowrap" }}>minato ws</div>
-        </div>
+        </button>
         {/* タイトル */}
         {editingTitle ? (
           <input

--- a/src/components/modals/ProjectShelfModal.tsx
+++ b/src/components/modals/ProjectShelfModal.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useStudio } from "../../contexts/StudioContext";
+
+export const ProjectShelfModal: React.FC = () => {
+  const {
+    projects,
+    activeProjectId,
+    setShowProjectShelf,
+    createProject,
+    switchProject,
+  } = useStudio();
+
+  return (
+    <div
+      onClick={() => setShowProjectShelf(false)}
+      style={{ position: "fixed", inset: 0, background: "rgba(5,8,15,0.72)", zIndex: 120, display: "flex", alignItems: "center", justifyContent: "center", padding: 16 }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ width: "min(760px, 96vw)", maxHeight: "82vh", overflowY: "auto", background: "#0a0f1a", border: "1px solid #1e2d42", borderRadius: 8, padding: 16 }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+          <div style={{ color: "#c8d8e8", fontWeight: 700 }}>本棚（執筆プロジェクト）</div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button onClick={createProject} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #2a6050", background: "rgba(42,128,96,0.12)", color: "#5ab090", cursor: "pointer", fontSize: 12, fontFamily: "inherit" }}>新規作成</button>
+            <button onClick={() => setShowProjectShelf(false)} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 12, fontFamily: "inherit" }}>閉じる</button>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {projects.map((project) => {
+            const isActive = project.id === activeProjectId;
+            return (
+              <button
+                key={project.id}
+                onClick={() => switchProject(project.id)}
+                style={{
+                  textAlign: "left",
+                  padding: "10px 12px",
+                  borderRadius: 6,
+                  border: isActive ? "1px solid #4a6fa5" : "1px solid #1a2535",
+                  background: isActive ? "rgba(74,111,165,0.14)" : "#0b111d",
+                  cursor: "pointer",
+                }}
+              >
+                <div style={{ fontSize: 13, color: isActive ? "#dce9f7" : "#c8d8e8", fontWeight: 600 }}>
+                  {project.title || "無題プロジェクト"}
+                  {isActive ? "（編集中）" : ""}
+                </div>
+                <div style={{ marginTop: 4, fontSize: 11, color: "#3a5570" }}>
+                  更新: {new Date(project.updatedAt).toLocaleString("ja-JP")} ・ シーン数: {project.scenes.length}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -9,7 +9,7 @@
 import React, { useEffect, useRef } from "react";
 import type { User } from "@supabase/supabase-js";
 import { storageGet, storageSet } from "../utils/storage";
-import type { Scene, Settings, Manuscripts, EditorSettings, AiHistoryItem, Backup } from "../types";
+import type { Scene, Settings, Manuscripts, EditorSettings, AiHistoryItem, Backup, ProjectRecord } from "../types";
 import { useStudioStore } from "../stores/useStudioStore";
 import { analyzeText } from "../utils/textAnalyzer";
 
@@ -26,7 +26,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
   useEffect(() => {
     (async () => {
       store.setLoaded(false);
-      const [sc, st, ms, pt, bk, es, ah, ab, sf, af] = await Promise.all([
+      const [sc, st, ms, pt, bk, es, ah, ab, sf, af, projects, activeProjectId] = await Promise.all([
         storageGet<Scene[]>("minato:scenes"),
         storageGet<Settings>("minato:settings"),
         storageGet<Manuscripts>("minato:manuscripts"),
@@ -37,7 +37,15 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
         storageGet<Backup[]>("minato:autoBackups"),
         storageGet<boolean>("minato:sidebarFloat"),
         storageGet<boolean>("minato:aiFloat"),
+        storageGet<ProjectRecord[]>("minato:projects"),
+        storageGet<string>("minato:activeProjectId"),
       ]);
+      const resolvedScenes = sc ?? store.scenes;
+      const resolvedSettings = st ?? store.settings;
+      const resolvedManuscripts = ms ?? store.manuscripts;
+      const resolvedTitle = pt ?? store.projectTitle;
+      const resolvedBackups = bk ?? store.backups;
+
       if (sc) store.setScenes(sc);
       if (st) store.setSettings(st);
       if (ms) store.setManuscripts(ms);
@@ -48,13 +56,34 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
       if (ab) store.setAutoBackups(ab);
       if (sf !== null) store.setSidebarFloat(sf);
       if (af !== null) store.setAiFloat(af);
+
+      const defaultProject: ProjectRecord = {
+        id: activeProjectId || "default",
+        title: resolvedTitle?.trim() || "無題プロジェクト",
+        updatedAt: new Date().toISOString(),
+        scenes: resolvedScenes,
+        manuscripts: resolvedManuscripts,
+        settings: resolvedSettings,
+        backups: resolvedBackups,
+      };
+      const loadedProjects = (projects && projects.length > 0) ? projects : [defaultProject];
+      const loadedActiveId = activeProjectId || loadedProjects[0].id;
+      const activeProject = loadedProjects.find(p => p.id === loadedActiveId) ?? loadedProjects[0];
+      store.setProjects(loadedProjects);
+      store.setActiveProjectId(activeProject.id);
+      store.setScenes(activeProject.scenes);
+      store.setManuscripts(activeProject.manuscripts);
+      store.setSettings(activeProject.settings);
+      store.setProjectTitle(activeProject.title);
+      store.setBackups(activeProject.backups);
+
       store.setLoaded(true);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id]);
 
   // --- Auto-save (debounced 1 s) ---
-  const { scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded } = store;
+  const { scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded, projects, activeProjectId, backups } = store;
 
   useEffect(() => {
     if (!loaded) return;
@@ -76,6 +105,21 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
           storageSet("minato:autoBackups", autoBackups),
           storageSet("minato:sidebarFloat", sidebarFloat),
           storageSet("minato:aiFloat", aiFloat),
+          storageSet("minato:activeProjectId", activeProjectId),
+          storageSet("minato:projects", (() => {
+            const now = new Date().toISOString();
+            const currentRecord: ProjectRecord = {
+              id: activeProjectId,
+              title: projectTitle.trim() || "無題プロジェクト",
+              updatedAt: now,
+              scenes,
+              manuscripts,
+              settings,
+              backups,
+            };
+            const rest = projects.filter(p => p.id !== activeProjectId);
+            return [currentRecord, ...rest];
+          })()),
         ]);
         if (results.every(r => r)) {
           store.setSaveStatus("saved");
@@ -91,7 +135,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
     const t = setTimeout(syncAll, 1000);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded]);
+  }, [scenes, settings, manuscripts, projectTitle, editorSettings, aiHistory, autoBackups, sidebarFloat, aiFloat, loaded, projects, activeProjectId, backups]);
 
   // --- Online / offline sync ---
   useEffect(() => {

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type {
   SceneStatus, Scene, Settings, Manuscripts, AppliedState,
-  AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem, TextMetrics, ImportData
+  AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem, TextMetrics, ImportData, ProjectRecord
 } from "../types";
 import { initialSettings, initialScenes } from "../constants";
 import { storageSet } from "../utils/storage";
@@ -63,6 +63,9 @@ export interface StudioState {
   showBackups: boolean;
   showImport: boolean;
   verticalPreview: boolean;
+  showProjectShelf: boolean;
+  activeProjectId: string;
+  projects: ProjectRecord[];
 
   // editor
   editorSettings: EditorSettings;
@@ -116,6 +119,9 @@ export interface StudioState {
   setShowBackups: (v: boolean) => void;
   setShowImport: (v: boolean) => void;
   setVerticalPreview: (v: boolean) => void;
+  setShowProjectShelf: (v: boolean) => void;
+  setActiveProjectId: (v: string) => void;
+  setProjects: (v: ProjectRecord[] | ((prev: ProjectRecord[]) => ProjectRecord[])) => void;
   setEditorSettings: (v: EditorSettings | ((prev: EditorSettings) => EditorSettings)) => void;
   setBackups: (v: Backup[] | ((prev: Backup[]) => Backup[])) => void;
   setAutoBackups: (v: Backup[] | ((prev: Backup[]) => Backup[])) => void;
@@ -145,6 +151,8 @@ export interface StudioState {
   exportScene: (fmt: "md" | "txt") => void;
   exportAll: (fmt: "md" | "txt") => void;
   importProject: (data: ImportData) => Promise<void>;
+  createProject: () => void;
+  switchProject: (id: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +205,9 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   showBackups: false,
   showImport: false,
   verticalPreview: false,
+  showProjectShelf: false,
+  activeProjectId: "default",
+  projects: [],
   editorSettings: { fontSize: 15, lineHeight: 2.2, colorTheme: "dark" },
   backups: [],
   autoBackups: [],
@@ -251,6 +262,9 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   setShowBackups: (v) => set({ showBackups: v }),
   setShowImport: (v) => set({ showImport: v }),
   setVerticalPreview: (v) => set({ verticalPreview: v }),
+  setShowProjectShelf: (v) => set({ showProjectShelf: v }),
+  setActiveProjectId: (v) => set({ activeProjectId: v }),
+  setProjects: (v) => set((s) => ({ projects: typeof v === "function" ? v(s.projects) : v })),
   setEditorSettings: (v) => set((s) => ({ editorSettings: typeof v === "function" ? v(s.editorSettings) : v })),
   setBackups: (v) => set((s) => ({ backups: typeof v === "function" ? v(s.backups) : v })),
   setAutoBackups: (v) => set((s) => ({ autoBackups: typeof v === "function" ? v(s.autoBackups) : v })),
@@ -420,6 +434,63 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       storageSet("minato:backups", newBackups),
     ]).catch(() => {/* ignore storage errors */});
   },
+
+  createProject: () => set((s) => {
+    const id = `project-${Date.now()}`;
+    const now = new Date().toISOString();
+    const currentTitle = s.projectTitle.trim() || "無題プロジェクト";
+    const currentProjects = s.projects.some(p => p.id === s.activeProjectId)
+      ? s.projects.map(p => p.id === s.activeProjectId
+        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }
+        : p)
+      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }, ...s.projects];
+    const nextProject: ProjectRecord = {
+      id,
+      title: "新規プロジェクト",
+      updatedAt: now,
+      scenes: initialScenes,
+      manuscripts: {},
+      settings: initialSettings,
+      backups: [],
+    };
+    return {
+      projects: [nextProject, ...currentProjects],
+      activeProjectId: id,
+      projectTitle: "新規プロジェクト",
+      scenes: initialScenes,
+      manuscripts: {},
+      settings: initialSettings,
+      backups: [],
+      selectedSceneId: null,
+      showProjectShelf: false,
+      ...computeDerived(initialScenes, {}, null),
+    };
+  }),
+
+  switchProject: (id) => set((s) => {
+    const target = s.projects.find(p => p.id === id);
+    if (!target) return {};
+    const now = new Date().toISOString();
+    const currentTitle = s.projectTitle.trim() || "無題プロジェクト";
+    const currentProjects = s.projects.some(p => p.id === s.activeProjectId)
+      ? s.projects.map(p => p.id === s.activeProjectId
+        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }
+        : p)
+      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }, ...s.projects];
+    const firstId = target.scenes[0]?.id ?? null;
+    return {
+      projects: currentProjects,
+      activeProjectId: target.id,
+      projectTitle: target.title,
+      scenes: target.scenes,
+      manuscripts: target.manuscripts,
+      settings: target.settings,
+      backups: target.backups,
+      selectedSceneId: firstId,
+      showProjectShelf: false,
+      ...computeDerived(target.scenes, target.manuscripts, firstId),
+    };
+  }),
 }));
 
 // テスト用: ストアを初期状態にリセットする
@@ -451,6 +522,9 @@ export function resetStudioStore() {
     showBackups: false,
     showImport: false,
     verticalPreview: false,
+    showProjectShelf: false,
+    activeProjectId: "default",
+    projects: [],
     editorSettings: { fontSize: 15, lineHeight: 2.2, colorTheme: "dark" },
     backups: [],
     autoBackups: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,3 +89,13 @@ export type ImportData = {
   settings: Partial<Settings>;
   projectTitle?: string;
 };
+
+export type ProjectRecord = {
+  id: string;
+  title: string;
+  updatedAt: string;
+  scenes: Scene[];
+  manuscripts: Manuscripts;
+  settings: Settings;
+  backups: Backup[];
+};


### PR DESCRIPTION
### Motivation
- Replace the top-left app icon with a bookshelf affordance that lets users open a project library (本棚) to switch writing projects. 
- Provide multi-project support so users can keep multiple project snapshots and switch between them without losing the current editing state.
- Persist a local project library so the project list and the active project survive reloads and can be restored on startup.

### Description
- Replaced the header icon with a clickable bookshelf button that calls `setShowProjectShelf(true)` in `src/components/layout/Header.tsx`.
- Added a new modal `src/components/modals/ProjectShelfModal.tsx` to list projects, create a new project (`createProject`) and switch projects (`switchProject`).
- Introduced `ProjectRecord` type in `src/types.ts` and added store fields/actions `showProjectShelf`, `activeProjectId`, `projects`, `createProject`, `switchProject` in `src/stores/useStudioStore.ts` with logic to snapshot current project on switch and create a fresh project.
- Extended `src/contexts/StudioContext.tsx` to load/save `minato:projects` and `minato:activeProjectId` and to include the active project when auto-saving, and added `ProjectShelfModal` rendering to `src/App.tsx`.
- Updated `src/__tests__/Header.test.tsx` mocks to include the newly-required `setShowProjectShelf` prop.

### Testing
- Ran type-checking with `npm run typecheck`, which completed successfully (no TypeScript errors).
- Ran the full test suite with `npm run test:run`, where all tests passed (`62` tests across `9` test files passed).
- Ran linter with `npm run lint`, which failed due to pre-existing lint errors in `src/components/ai/AiAssistant.tsx` (two `no-empty` errors reported) that are unrelated to this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5279da29c8323b0493198fcc10be7)