### PR TITLE
起動時にオフライン起動の選択肢を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,14 +20,19 @@ import { StudioProvider, useStudio } from "./contexts/StudioContext";
 export default function App() {
   const [user, setUser] = useState<User | null>(null);
   const [authLoading, setAuthLoading] = useState(true);
+  const [launchMode, setLaunchMode] = useState<"select" | "offline" | "authenticated">("select");
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setUser(session?.user ?? null);
+      setLaunchMode(session?.user ? "authenticated" : "select");
       setAuthLoading(false);
     });
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, session) => {
       setUser(session?.user ?? null);
+      if (session?.user) {
+        setLaunchMode("authenticated");
+      }
       setAuthLoading(false);
     });
     return () => subscription.unsubscribe();
@@ -40,7 +45,7 @@ export default function App() {
     </div>
   );
 
-  if (!user) return (
+  if (!user && launchMode === "select") return (
     <div style={{ height: "100dvh", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", background: "#0a0e1a", gap: 24 }}>
       <div>
         <svg width="32" height="32" viewBox="0 0 28 28" fill="none">
@@ -55,12 +60,37 @@ export default function App() {
         <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textAlign: "center", marginTop: 4 }}>minato ws</div>
       </div>
       <div style={{ fontSize: 18, color: "#c8d8e8", fontWeight: 700, fontFamily: "'Noto Serif JP','Georgia',serif", letterSpacing: 1 }}>minato Writing Studio</div>
-      <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{
-        padding: "10px 28px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5",
-        color: "#7ab3e0", cursor: "pointer", borderRadius: 6, fontSize: 13, fontFamily: "inherit", letterSpacing: 1,
-      }}>Googleでログイン</button>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10 }}>
+        <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{
+          padding: "10px 28px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5",
+          color: "#7ab3e0", cursor: "pointer", borderRadius: 6, fontSize: 13, fontFamily: "inherit", letterSpacing: 1,
+        }}>Googleでログイン</button>
+        <button
+          onClick={() => setLaunchMode("offline")}
+          style={{
+            padding: "10px 28px", background: "transparent", border: "1px solid #2a4060",
+            color: "#6f8baa", cursor: "pointer", borderRadius: 6, fontSize: 12, fontFamily: "inherit", letterSpacing: 1,
+          }}
+        >
+          オフラインで開始
+        </button>
+      </div>
+      <p style={{ margin: 0, fontSize: 12, color: "#58769a", textAlign: "center", lineHeight: 1.8 }}>
+        DBログインすると端末間でデータを同期できます。<br />
+        オフライン起動時は、この端末のローカル保存のみ利用します。
+      </p>
     </div>
   );
+
+  if (!user && launchMode === "offline") {
+    return (
+      <ErrorBoundary>
+        <StudioProvider user={null}>
+          <Studio />
+        </StudioProvider>
+      </ErrorBoundary>
+    );
+  }
 
   return (
     <ErrorBoundary>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { expect, test, vi, describe } from "vitest";
 import "@testing-library/jest-dom";
 import App from "../App";
@@ -29,16 +29,21 @@ describe("App", () => {
     expect(titleElement).toBeInTheDocument();
   });
 
-  test("renders Google login button when not authenticated", async () => {
+  test("renders startup options and sync guidance when not authenticated", async () => {
     render(<App />);
     const loginButton = await screen.findByRole("button", { name: /Googleでログイン/ });
+    const offlineButton = await screen.findByRole("button", { name: /オフラインで開始/ });
     expect(loginButton).toBeInTheDocument();
+    expect(offlineButton).toBeInTheDocument();
+    expect(await screen.findByText(/DBログインすると端末間でデータを同期できます/)).toBeInTheDocument();
   });
 
-  test("transitions from loading to login screen", async () => {
+  test("transitions from startup selection to studio on offline launch", async () => {
     render(<App />);
-    // Wait for async auth to resolve and login screen to appear
-    const loginButton = await screen.findByRole("button", { name: /Googleでログイン/ });
-    expect(loginButton).toBeInTheDocument();
+    const offlineButton = await screen.findByRole("button", { name: /オフラインで開始/ });
+    fireEvent.click(offlineButton);
+    await waitFor(() => {
+      expect(screen.queryByText(/DBログインすると端末間でデータを同期できます/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -17,7 +17,7 @@ import { analyzeText } from "../utils/textAnalyzer";
 // Provider: side effects only
 // ---------------------------------------------------------------------------
 
-export function StudioProvider({ children, user }: { children: React.ReactNode; user: User }) {
+export function StudioProvider({ children, user }: { children: React.ReactNode; user: User | null }) {
   const store = useStudioStore();
   const syncAllRef = useRef<() => Promise<void>>(async () => {});
   const skipInitialSaveRef = useRef(true);


### PR DESCRIPTION
### Motivation
- 未ログイン時にユーザーがオンライン（DB同期）かローカルのみ（オフライン）で起動するかを選べるようにして、端末間同期の挙動を明示するための変更です。
- ログインなしでアプリを使いたいケースに対応し、ローカル保存のみで Studio を起動できるようにするためです。

### Description
- `App.tsx` に `launchMode` (`select | offline | authenticated`) を追加して起動時の選択フローを導入しました。
- 未ログイン時は「Googleでログイン」と「オフラインで開始」のボタンと `DBログインすると端末間でデータを同期できます` の説明文を表示するようにしました。
- `オフラインで開始` 選択時は `StudioProvider` に `user={null}` を渡してログイン不要で `Studio` をレンダリングするパスを追加しました。
- `StudioContext.tsx` の `StudioProvider` の `user` 型を `User | null` に拡張してオフライン起動に対応し、テスト `src/__tests__/App.test.tsx` を起動オプションとオフライン遷移を検証するように更新しました。

### Testing
- 単体テスト（変更ファイルのみ）を `npm test -- --run src/__tests__/App.test.tsx` で実行し成功しました.
- フルテストスイートを `npm test -- --run` で実行し全テストが成功（62 tests passed）しましたが、`StudioContext.test.tsx` 由来の `act(...)` に関する React の警告が出力されました（警告であり失敗ではありません）。
- 環境内での外部検索確認はネットワーク制約により `curl` が失敗しましたが、機能・自動テストは通過しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53cc2bba883238f7d8f3db77666b0)