### PR TITLE
fix(YUY-31): 固定モード時のみリサイズハンドルを表示・位置を修正

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -152,6 +152,7 @@ export const Sidebar: React.FC = () => {
 
   return (
     <aside style={{
+      position: "relative",
       width: sidebarOpen ? effectiveSidebarWidth : 36,
       borderRight: "1px solid #1e2d42",
       background: "#080c16",
@@ -163,7 +164,7 @@ export const Sidebar: React.FC = () => {
         position: "absolute", left: 0, top: 0, bottom: 0, zIndex: 51, width: effectiveSidebarWidth, boxShadow: "4px 0 20px rgba(0,0,0,0.6)"
       } : {}),
     }}>
-      {sidebarOpen && (
+      {sidebarOpen && !sidebarFloat && (
         <div
           onPointerDown={(e) => {
             dragStartXRef.current = e.clientX;


### PR DESCRIPTION
- aside に position: relative を追加し、固定モード時に リサイズハンドル(right: -5)が親コンテナ基準でなく aside 基準で配置されるよう修正
- 表示条件を !sidebarFloat に戻し、固定モード時のみ表示