### PR TITLE
fix(YUY-40): 退出ボタンでログアウトされない問題を修正し再ログインボタンを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,9 +30,7 @@ export default function App() {
     });
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, session) => {
       setUser(session?.user ?? null);
-      if (session?.user) {
-        setLaunchMode("authenticated");
-      }
+      setLaunchMode(session?.user ? "authenticated" : "select");
       setAuthLoading(false);
     });
     return () => subscription.unsubscribe();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,8 @@ export const Header: React.FC = () => {
   const {
     projectTitle, setProjectTitle, editingTitle, setEditingTitle,
     saveStatus, lastSavedTime, scenes, settings, manuscripts,
-    saveWithBackup, setShowBackups, setShowExport, setShowImport, setShowProjectShelf
+    saveWithBackup, setShowBackups, setShowExport, setShowImport, setShowProjectShelf,
+    user,
   } = useStudio();
   const hasProjectTitle = projectTitle.trim().length > 0;
 
@@ -70,7 +71,11 @@ export const Header: React.FC = () => {
         <button onClick={() => setShowBackups(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>履歴</button>
         <button onClick={() => setShowImport(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>取込</button>
         <button onClick={() => setShowExport(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>出力</button>
-        <button onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>退出</button>
+        {user ? (
+          <button onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>退出</button>
+        ) : (
+          <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>ログイン</button>
+        )}
       </div>
     </header>
   );

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -22,6 +22,12 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
   const syncAllRef = useRef<() => Promise<void>>(async () => {});
   const skipInitialSaveRef = useRef(true);
 
+  // --- Sync user to store ---
+  useEffect(() => {
+    store.setUser(user);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
   // --- Initial load ---
   useEffect(() => {
     (async () => {

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { User } from "@supabase/supabase-js";
 import type {
   SceneStatus, Scene, Settings, Manuscripts, AppliedState,
   AiResults, AiLoading, AiErrors, Backup, SceneDraft, EditorSettings, TabKey, SidebarTabKey, SaveStatus, AiHistoryItem, TextMetrics, ImportData, ProjectRecord
@@ -26,6 +27,9 @@ function computeDerived(
 // ---------------------------------------------------------------------------
 
 export interface StudioState {
+  // auth
+  user: User | null;
+
   // persistence / loading
   loaded: boolean;
   saveStatus: SaveStatus;
@@ -95,6 +99,7 @@ export interface StudioState {
   // ---------------------------------------------------------------------------
   // Setters (plain state updates)
   // ---------------------------------------------------------------------------
+  setUser: (v: User | null) => void;
   setLoaded: (v: boolean) => void;
   setSaveStatus: (v: SaveStatus) => void;
   setLastSavedTime: (v: Date | null) => void;
@@ -183,6 +188,7 @@ function downloadFile(content: string, filename: string) {
 
 export const useStudioStore = create<StudioState>((set, get) => ({
   // Initial state
+  user: null,
   loaded: false,
   saveStatus: "saved",
   lastSavedTime: null,
@@ -233,6 +239,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   // ---------------------------------------------------------------------------
   // Setters
   // ---------------------------------------------------------------------------
+  setUser: (v) => set({ user: v }),
   setLoaded: (v) => set({ loaded: v }),
   setSaveStatus: (v) => set({ saveStatus: v }),
   setLastSavedTime: (v) => set({ lastSavedTime: v }),


### PR DESCRIPTION
## Summary
- `onAuthStateChange` でサインアウト時に `launchMode` を `"select"` に戻すよう修正（以前は `"authenticated"` のままで Studio がオフラインモードとして動き続けていた）
- `useStudioStore` に `user` フィールドを追加し、Header から認証状態を参照できるようにした
- Header でオフラインモード（`user === null`）の場合「ログイン」ボタンを表示、認証済みの場合のみ「退出」ボタンを表示

## Fixes
- Closes [YUY-40](https://linear.app/yuyuiklala/issue/YUY-40/退出ボタンでログアウトされない)

## Test plan
- [ ] ログイン状態で「退出」ボタンを押すと、ログイン選択画面に戻ることを確認
- [ ] オフラインモードで「ログイン」ボタンが表示されることを確認
- [ ] 「ログイン」ボタンを押すと Google OAuth フローが開始されることを確認
- [ ] 全64テスト通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)