### PR TITLE
fix(YUY-41/42/44): タイトル未反映・AI履歴未分離・文字化けバグを修正

### DIFF
--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -49,7 +49,20 @@ export function ImportModal() {
     setError(null);
     setStep("analyzing");
 
-    const text = await file.text();
+    const buffer = await file.arrayBuffer();
+    const uint8 = new Uint8Array(buffer);
+    let text: string;
+    // UTF-8 BOM チェック
+    if (uint8[0] === 0xEF && uint8[1] === 0xBB && uint8[2] === 0xBF) {
+      text = new TextDecoder("utf-8").decode(buffer);
+    } else {
+      // UTF-8 として厳密に試み、失敗したら Shift-JIS にフォールバック
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+      } catch {
+        text = new TextDecoder("shift-jis").decode(buffer);
+      }
+    }
 
     const [parsed, aiResult] = await Promise.all([
       parseDocument(text),

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -86,6 +86,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
       store.setSettings(activeProject.settings);
       store.setProjectTitle(activeProject.title);
       store.setBackups(activeProject.backups);
+      if (activeProject.aiHistory != null) store.setAiHistory(activeProject.aiHistory);
 
       store.setLoaded(true);
     })();
@@ -126,6 +127,7 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
             manuscripts,
             settings,
             backups,
+            aiHistory,
           };
           const rest = projects.filter(p => p.id !== activeProjectId);
           return [currentRecord, ...rest];

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -259,7 +259,12 @@ export const useStudioStore = create<StudioState>((set, get) => ({
     return { manuscripts: next, ...computeDerived(s.scenes, next, s.selectedSceneId) };
   }),
   setSettings: (v) => set((s) => ({ settings: typeof v === "function" ? v(s.settings) : v })),
-  setProjectTitle: (v) => set({ projectTitle: v }),
+  setProjectTitle: (v) => set((s) => ({
+    projectTitle: v,
+    projects: s.projects.map(p =>
+      p.id === s.activeProjectId ? { ...p, title: v } : p
+    ),
+  })),
   setSidebarOpen: (v) => set({ sidebarOpen: v }),
   setSidebarFloat: (v) => set({ sidebarFloat: v }),
   setSidebarWidth: (v) => set({ sidebarWidth: v }),
@@ -456,9 +461,9 @@ export const useStudioStore = create<StudioState>((set, get) => ({
     const currentTitle = s.projectTitle.trim() || "無題プロジェクト";
     const currentProjects = s.projects.some(p => p.id === s.activeProjectId)
       ? s.projects.map(p => p.id === s.activeProjectId
-        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }
+        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }
         : p)
-      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }, ...s.projects];
+      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }, ...s.projects];
     const nextProject: ProjectRecord = {
       id,
       title: "新規プロジェクト",
@@ -467,6 +472,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       manuscripts: {},
       settings: initialSettings,
       backups: [],
+      aiHistory: [],
     };
     return {
       projects: [nextProject, ...currentProjects],
@@ -476,6 +482,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       manuscripts: {},
       settings: initialSettings,
       backups: [],
+      aiHistory: [],
       selectedSceneId: null,
       showProjectShelf: false,
       ...computeDerived(initialScenes, {}, null),
@@ -489,9 +496,9 @@ export const useStudioStore = create<StudioState>((set, get) => ({
     const currentTitle = s.projectTitle.trim() || "無題プロジェクト";
     const currentProjects = s.projects.some(p => p.id === s.activeProjectId)
       ? s.projects.map(p => p.id === s.activeProjectId
-        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }
+        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }
         : p)
-      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups }, ...s.projects];
+      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }, ...s.projects];
     const firstId = target.scenes[0]?.id ?? null;
     return {
       projects: currentProjects,
@@ -501,6 +508,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       manuscripts: target.manuscripts,
       settings: target.settings,
       backups: target.backups,
+      aiHistory: target.aiHistory ?? [],
       selectedSceneId: firstId,
       showProjectShelf: false,
       ...computeDerived(target.scenes, target.manuscripts, firstId),

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,4 +98,5 @@ export type ProjectRecord = {
   manuscripts: Manuscripts;
   settings: Settings;
   backups: Backup[];
+  aiHistory?: AiHistoryItem[];
 };


### PR DESCRIPTION
## Summary
- **YUY-41** タイトル変更がプロジェクト選択画面に反映されない
- **YUY-42** AI履歴がプロジェクト単位で切り替わらない
- **YUY-44** 取り込みファイルのエンコード形式によって文字化けする

## 変更内容

### YUY-41
`setProjectTitle` が `projectTitle` のみ更新していたため、本棚モーダルが古いタイトルを表示していた。`projects[]` 内の対応レコードも同時更新するよう修正。

### YUY-42
`ProjectRecord` に `aiHistory` が含まれていなかったため、プロジェクト切替時に全プロジェクト共通の履歴が表示されていた。  
- `types.ts`: `ProjectRecord` に `aiHistory?: AiHistoryItem[]` を追加  
- `createProject` / `switchProject`: 現プロジェクトの履歴を保存・切替先の履歴を復元  
- `StudioContext`: 自動保存・初期ロード時に `aiHistory` を含めるよう対応  

### YUY-44
`file.text()` は UTF-8 固定のため Shift-JIS ファイルで文字化けしていた。  
`ArrayBuffer` で読み込み、UTF-8 BOM → UTF-8 strict → Shift-JIS の順にフォールバック検出するよう修正。

## Fixes
- Closes [YUY-41](https://linear.app/yuyuiklala/issue/YUY-41)
- Closes [YUY-42](https://linear.app/yuyuiklala/issue/YUY-42)
- Closes [YUY-44](https://linear.app/yuyuiklala/issue/YUY-44)

## Test plan
- [ ] タイトル編集後に本棚を開くと新しいタイトルが表示される
- [ ] プロジェクト切替でAI履歴がプロジェクトごとに切り替わる
- [ ] Shift-JISの.txtファイルをインポートしても文字化けしない
- [ ] 全64テスト通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)