### PR TITLE
fix(YUY-34/35/45): AI提案保持・サイドパネル展開・スクロールバー改善

### DIFF
--- a/src/components/ai/AiPanel.tsx
+++ b/src/components/ai/AiPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import { callAnthropic, AiError } from "../../utils/ai";
 
 type AiPanelProps = {
@@ -30,6 +30,12 @@ export function AiPanel({
   useEffect(() => {
     onAppendRef.current = onAppend;
   });
+
+  // YUY-34: 「閉じる」で結果をストアから消さず、ローカルで非表示にする
+  const [dismissed, setDismissed] = useState(false);
+  useEffect(() => {
+    if (result) setDismissed(false);
+  }, [result]);
 
   const run = async () => {
     onLoading(true);
@@ -96,7 +102,7 @@ export function AiPanel({
         </div>
       )}
 
-      {result && (
+      {result && !dismissed && (
         <div
           style={{
             marginTop: 8,
@@ -132,7 +138,7 @@ export function AiPanel({
                 追記
               </button>
               <button
-                onClick={() => onResult("")}
+                onClick={() => setDismissed(true)}
                 style={{
                   padding: "3px 10px",
                   background: "transparent",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -502,7 +502,7 @@ export const Sidebar: React.FC = () => {
         </>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 4 }}>
-          <button onClick={() => setSidebarOpen(true)} style={{ padding: "8px 0", width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>▶</button>
+          <button onClick={() => { setSidebarOpen(true); setTab("write"); }} style={{ padding: "8px 0", width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>▶</button>
           {[
             { key: "write", label: "執筆" },
             { key: "structure", label: "構成" },

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,22 @@
+/* YUY-45: カスタムスクロールバー */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #1e2d42;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #2a4060;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { supabase } from "./supabase";
 import App from "./App";
+import "./index.css";
 
 supabase.auth.getSession().then(() => {
   createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- **YUY-34** 続きを提案「閉じる」で内容が消える問題を修正
- **YUY-35** サイドパネル展開ボタンでメインペインを執筆画面に戻す
- **YUY-45** スクロールスライダーを専用デザインに

## 変更内容

### YUY-34
`AiPanel` の「閉じる」ボタンが `onResult("")` でストアの結果を消していた。  
`dismissed` ローカル状態を追加し、「閉じる」はビジュアル非表示のみにして結果をストアに残すよう変更。  
新しい生成結果が来ると `dismissed` は自動リセットされる。

### YUY-35
折り畳みサイドバーの ▶ ボタンが `setSidebarOpen(true)` のみだったため、メインペインのタブが変わらなかった。  
`setTab("write")` も同時に呼ぶよう修正。

### YUY-45
`src/index.css` を新規作成し `::-webkit-scrollbar` スタイルをアプリ全体に適用。  
細め(6px) のダーク系スクロールバーでテーマと統一。

## Fixes
- Closes [YUY-34](https://linear.app/yuyuiklala/issue/YUY-34)
- Closes [YUY-35](https://linear.app/yuyuiklala/issue/YUY-35)
- Closes [YUY-45](https://linear.app/yuyuiklala/issue/YUY-45)

## Test plan
- [ ] 「続きを提案」で結果表示後に「閉じる」を押しても AI 履歴に残ることを確認
- [ ] 再生成すると前回結果が上書きされ dismissed がリセットされることを確認
- [ ] 折り畳みサイドバーの ▶ ボタンで、設定タブ表示中でも執筆画面に戻ることを確認
- [ ] スクロールバーがダーク系の細いデザインになることを確認
- [ ] 全64テスト通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)