### PR TITLE
feat(YUY-38/43): 取り込みモード選択と zip ファイル対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
+        "fflate": "^0.8.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "zustand": "^5.0.11"
@@ -5694,6 +5695,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
+    "fflate": "^0.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zustand": "^5.0.11"

--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -5,6 +5,7 @@ import { extractImportMetadata } from "../../utils/importExtractor";
 import type { ImportData, ParsedSection } from "../../types";
 
 type Step = "pick" | "analyzing" | "preview";
+type ImportMode = "new" | "append" | "replace";
 
 const BTN: React.CSSProperties = {
   padding: "8px 16px",
@@ -28,6 +29,18 @@ const TEXTAREA: React.CSSProperties = {
   boxSizing: "border-box",
 };
 
+/** Uint8Array をエンコード自動検出してデコードする */
+function decodeBuffer(uint8: Uint8Array): string {
+  if (uint8[0] === 0xEF && uint8[1] === 0xBB && uint8[2] === 0xBF) {
+    return new TextDecoder("utf-8").decode(uint8);
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(uint8);
+  } catch {
+    return new TextDecoder("shift-jis").decode(uint8);
+  }
+}
+
 export function ImportModal() {
   const store = useStudioStore();
   const fileRef = useRef<HTMLInputElement>(null);
@@ -40,40 +53,56 @@ export function ImportModal() {
   const [sections, setSections] = useState<ParsedSection[]>([]);
   const [characters, setCharacters] = useState("");
   const [world, setWorld] = useState("");
+  const [importMode, setImportMode] = useState<ImportMode>("new");
 
   const handleFile = useCallback(async (file: File) => {
-    if (!file.name.match(/\.(md|txt)$/i)) {
-      setError(".md または .txt ファイルを選択してください");
+    const isZip = /\.zip$/i.test(file.name);
+    const isText = /\.(md|txt)$/i.test(file.name);
+    if (!isZip && !isText) {
+      setError(".md / .txt / .zip ファイルを選択してください");
       return;
     }
     setError(null);
     setStep("analyzing");
 
-    const buffer = await file.arrayBuffer();
-    const uint8 = new Uint8Array(buffer);
-    let text: string;
-    // UTF-8 BOM チェック
-    if (uint8[0] === 0xEF && uint8[1] === 0xBB && uint8[2] === 0xBF) {
-      text = new TextDecoder("utf-8").decode(buffer);
-    } else {
-      // UTF-8 として厳密に試み、失敗したら Shift-JIS にフォールバック
+    let combinedText: string;
+    let titleFromFile: string;
+
+    if (isZip) {
+      // YUY-43: zip 展開
+      const buffer = await file.arrayBuffer();
+      const { unzipSync } = await import("fflate");
+      let unzipped: Record<string, Uint8Array>;
       try {
-        text = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+        unzipped = unzipSync(new Uint8Array(buffer));
       } catch {
-        text = new TextDecoder("shift-jis").decode(buffer);
+        setError("zip ファイルの展開に失敗しました");
+        setStep("pick");
+        return;
       }
+      const textFiles = Object.entries(unzipped)
+        .filter(([name]) => /\.(md|txt)$/i.test(name) && !name.includes("__MACOSX"))
+        .sort(([a], [b]) => a.localeCompare(b, "ja"));
+      if (textFiles.length === 0) {
+        setError("zip 内に .md / .txt ファイルが見つかりませんでした");
+        setStep("pick");
+        return;
+      }
+      combinedText = textFiles.map(([, data]) => decodeBuffer(data)).join("\n\n");
+      titleFromFile = file.name.replace(/\.zip$/i, "");
+    } else {
+      const buffer = await file.arrayBuffer();
+      combinedText = decodeBuffer(new Uint8Array(buffer));
+      titleFromFile = file.name.replace(/\.(md|txt)$/i, "");
     }
 
     const [parsed, aiResult] = await Promise.all([
-      parseDocument(text),
-      extractImportMetadata(text),
+      parseDocument(combinedText),
+      extractImportMetadata(combinedText.slice(0, 3000)),
     ]);
 
-    const detectedTitle = parsed?.title || file.name.replace(/\.(md|txt)$/i, "");
-    const detectedSections = parsed?.sections ?? [{ chapter: "", title: "", content: text }];
-
-    setProjectTitle(detectedTitle);
-    setSections(detectedSections);
+    setProjectTitle(parsed?.title || titleFromFile);
+    setSections(parsed?.sections ?? [{ chapter: "", title: "", content: combinedText }]);
     setCharacters(aiResult?.characters ?? "");
     setWorld(aiResult?.world ?? "");
     setStep("preview");
@@ -101,17 +130,27 @@ export function ImportModal() {
       status: "draft" as const,
     }));
     const manuscripts: Record<number, string> = {};
-    scenes.forEach((sc, i) => {
-      manuscripts[sc.id] = sections[i].content;
-    });
+    scenes.forEach((sc, i) => { manuscripts[sc.id] = sections[i].content; });
     const data: ImportData = {
       scenes,
       manuscripts,
       settings: { characters, world },
       projectTitle: projectTitle || undefined,
     };
-    await store.importProject(data);
-  }, [sections, characters, world, projectTitle, store]);
+    if (importMode === "new") {
+      store.createProjectFromImport(data);
+    } else if (importMode === "append") {
+      await store.appendToProject(data);
+    } else {
+      await store.importProject(data);
+    }
+  }, [sections, characters, world, projectTitle, importMode, store]);
+
+  const IMPORT_MODES: { mode: ImportMode; label: string; desc: string }[] = [
+    { mode: "new", label: "新規プロジェクト", desc: "現在のプロジェクトを残したまま新しいプロジェクトを作成します" },
+    { mode: "append", label: "現在に追加", desc: "現在のプロジェクトの末尾にシーンを追加します（設定は変更しません）" },
+    { mode: "replace", label: "現在を置き換え", desc: "現在のプロジェクトを置き換えます（バックアップ自動生成）" },
+  ];
 
   return (
     <div
@@ -165,11 +204,11 @@ export function ImportModal() {
               }}
             >
               <span style={{ fontSize: 28 }}>↑</span>
-              <span>.md / .txt をドロップ、またはクリックして選択</span>
+              <span>.md / .txt / .zip をドロップ、またはクリックして選択</span>
               <input
                 ref={fileRef}
                 type="file"
-                accept=".md,.txt"
+                accept=".md,.txt,.zip"
                 style={{ display: "none" }}
                 onChange={onFileChange}
               />
@@ -199,19 +238,45 @@ export function ImportModal() {
         {/* ── Step 3: Preview ── */}
         {step === "preview" && (
           <>
+            {/* YUY-38: インポートモード選択 */}
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 6 }}>
+                インポート方法
+              </label>
+              <div style={{ display: "flex", gap: 6 }}>
+                {IMPORT_MODES.map(({ mode, label }) => (
+                  <button
+                    key={mode}
+                    onClick={() => setImportMode(mode)}
+                    style={{
+                      flex: 1,
+                      padding: "6px 4px",
+                      background: importMode === mode ? "rgba(74,111,165,0.2)" : "transparent",
+                      border: `1px solid ${importMode === mode ? "#4a6fa5" : "#2a3f58"}`,
+                      color: importMode === mode ? "#7ab3e0" : "#4a6080",
+                      borderRadius: 4,
+                      cursor: "pointer",
+                      fontSize: 11,
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <div style={{ marginTop: 4, fontSize: 10, color: "#3a5070" }}>
+                {IMPORT_MODES.find(m => m.mode === importMode)?.desc}
+              </div>
+            </div>
+
             <div style={{ marginBottom: 16 }}>
               <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 4 }}>
-                プロジェクト名
+                {importMode === "new" ? "新規プロジェクト名" : "プロジェクト名（参考）"}
               </label>
               <input
                 value={projectTitle}
                 onChange={(e) => setProjectTitle(e.target.value)}
-                style={{
-                  ...TEXTAREA,
-                  minHeight: "unset",
-                  height: 32,
-                  resize: "none",
-                }}
+                style={{ ...TEXTAREA, minHeight: "unset", height: 32, resize: "none" }}
               />
             </div>
 
@@ -219,14 +284,7 @@ export function ImportModal() {
               <div style={{ fontSize: 11, color: "#5a8aaa", marginBottom: 8 }}>
                 検出シーン（{sections.length} 件）
               </div>
-              <div
-                style={{
-                  border: "1px solid #1e2d42",
-                  borderRadius: 4,
-                  maxHeight: 160,
-                  overflowY: "auto",
-                }}
-              >
+              <div style={{ border: "1px solid #1e2d42", borderRadius: 4, maxHeight: 160, overflowY: "auto" }}>
                 {sections.map((s, i) => (
                   <div
                     key={i}
@@ -236,12 +294,8 @@ export function ImportModal() {
                       fontSize: 11,
                     }}
                   >
-                    <span style={{ color: "#4a7090" }}>
-                      {s.chapter ? `${s.chapter} / ` : ""}
-                    </span>
-                    <span style={{ color: "#7ab3e0" }}>
-                      {s.title || `（タイトルなし）`}
-                    </span>
+                    <span style={{ color: "#4a7090" }}>{s.chapter ? `${s.chapter} / ` : ""}</span>
+                    <span style={{ color: "#7ab3e0" }}>{s.title || "（タイトルなし）"}</span>
                     <span style={{ color: "#3a5570", marginLeft: 8 }}>
                       {s.content.slice(0, 40).replace(/\n/g, " ")}
                       {s.content.length > 40 ? "…" : ""}
@@ -251,59 +305,52 @@ export function ImportModal() {
               </div>
             </div>
 
-            <div style={{ marginBottom: 16 }}>
-              <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 4 }}>
-                キャラクター（AI 抽出・編集可）
-              </label>
-              <textarea
-                value={characters}
-                onChange={(e) => setCharacters(e.target.value)}
-                placeholder="（抽出できませんでした。手入力してください）"
-                style={TEXTAREA}
-              />
-            </div>
-
-            <div style={{ marginBottom: 24 }}>
-              <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 4 }}>
-                世界観（AI 抽出・編集可）
-              </label>
-              <textarea
-                value={world}
-                onChange={(e) => setWorld(e.target.value)}
-                placeholder="（抽出できませんでした。手入力してください）"
-                style={TEXTAREA}
-              />
-            </div>
+            {importMode !== "append" && (
+              <>
+                <div style={{ marginBottom: 16 }}>
+                  <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 4 }}>
+                    キャラクター（AI 抽出・編集可）
+                  </label>
+                  <textarea
+                    value={characters}
+                    onChange={(e) => setCharacters(e.target.value)}
+                    placeholder="（抽出できませんでした。手入力してください）"
+                    style={TEXTAREA}
+                  />
+                </div>
+                <div style={{ marginBottom: 24 }}>
+                  <label style={{ fontSize: 11, color: "#5a8aaa", display: "block", marginBottom: 4 }}>
+                    世界観（AI 抽出・編集可）
+                  </label>
+                  <textarea
+                    value={world}
+                    onChange={(e) => setWorld(e.target.value)}
+                    placeholder="（抽出できませんでした。手入力してください）"
+                    style={TEXTAREA}
+                  />
+                </div>
+              </>
+            )}
 
             <div style={{ display: "flex", gap: 8 }}>
               <button
                 onClick={() => store.setShowImport(false)}
-                style={{
-                  ...BTN,
-                  flex: 1,
-                  background: "transparent",
-                  border: "1px solid #1e2d42",
-                  color: "#3a5570",
-                }}
+                style={{ ...BTN, flex: 1, background: "transparent", border: "1px solid #1e2d42", color: "#3a5570" }}
               >
                 キャンセル
               </button>
               <button
                 onClick={handleImport}
-                style={{
-                  ...BTN,
-                  flex: 2,
-                  background: "rgba(74,111,165,0.2)",
-                  border: "1px solid #4a6fa5",
-                  color: "#7ab3e0",
-                }}
+                style={{ ...BTN, flex: 2, background: "rgba(74,111,165,0.2)", border: "1px solid #4a6fa5", color: "#7ab3e0" }}
               >
                 インポート実行
               </button>
             </div>
 
             <div style={{ marginTop: 10, fontSize: 10, color: "#2a3f58", textAlign: "center" }}>
-              現在のデータはインポート前にバックアップされます
+              {importMode === "replace" && "現在のデータはインポート前にバックアップされます"}
+              {importMode === "append" && "現在のシーンの末尾に追加されます"}
+              {importMode === "new" && "現在のプロジェクトはそのまま保持されます"}
             </div>
           </>
         )}

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -160,6 +160,8 @@ export interface StudioState {
   exportScene: (fmt: "md" | "txt") => void;
   exportAll: (fmt: "md" | "txt") => void;
   importProject: (data: ImportData) => Promise<void>;
+  appendToProject: (data: ImportData) => Promise<void>;
+  createProjectFromImport: (data: ImportData) => void;
   createProject: () => void;
   switchProject: (id: string) => void;
 }
@@ -453,6 +455,75 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       storageSet("minato:title", newTitle),
       storageSet("minato:backups", newBackups),
     ]).catch(() => {/* ignore storage errors */});
+  },
+
+  // YUY-38: 既存プロジェクトにシーンを追加（設定・タイトルは変更しない）
+  appendToProject: async (data) => {
+    const { scenes, manuscripts, settings, projectTitle, backups } = get();
+    const backup: Backup = {
+      timestamp: new Date().toISOString(),
+      label: "シーン追加前の自動バックアップ",
+      scenes, manuscripts, settings, projectTitle,
+    };
+    const newBackups = [backup, ...backups].slice(0, 5);
+    const newScenes = [...scenes, ...data.scenes];
+    const newManuscripts = { ...manuscripts, ...data.manuscripts };
+    const firstNewId = data.scenes[0]?.id ?? null;
+    set({
+      backups: newBackups,
+      scenes: newScenes,
+      manuscripts: newManuscripts,
+      selectedSceneId: firstNewId,
+      showImport: false,
+      tab: "write",
+      textMetrics: null,
+      ...computeDerived(newScenes, newManuscripts, firstNewId),
+    });
+    await Promise.all([
+      storageSet("minato:scenes", newScenes),
+      storageSet("minato:manuscripts", newManuscripts),
+      storageSet("minato:backups", newBackups),
+    ]).catch(() => {});
+  },
+
+  // YUY-38: 新規プロジェクトを作成してインポート
+  createProjectFromImport: (data) => {
+    const s = get();
+    const id = `project-${Date.now()}`;
+    const now = new Date().toISOString();
+    const currentTitle = s.projectTitle.trim() || "無題プロジェクト";
+    const currentProjects = s.projects.some(p => p.id === s.activeProjectId)
+      ? s.projects.map(p => p.id === s.activeProjectId
+        ? { ...p, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }
+        : p)
+      : [{ id: s.activeProjectId, title: currentTitle, updatedAt: now, scenes: s.scenes, manuscripts: s.manuscripts, settings: s.settings, backups: s.backups, aiHistory: s.aiHistory }, ...s.projects];
+    const newTitle = data.projectTitle || "インポートプロジェクト";
+    const mergedSettings: Settings = {
+      world: data.settings.world || initialSettings.world,
+      characters: data.settings.characters || initialSettings.characters,
+      theme: initialSettings.theme,
+    };
+    const firstId = data.scenes[0]?.id ?? null;
+    const newProject: ProjectRecord = {
+      id, title: newTitle, updatedAt: now,
+      scenes: data.scenes, manuscripts: data.manuscripts,
+      settings: mergedSettings, backups: [], aiHistory: [],
+    };
+    set({
+      projects: [newProject, ...currentProjects],
+      activeProjectId: id,
+      projectTitle: newTitle,
+      scenes: data.scenes,
+      manuscripts: data.manuscripts,
+      settings: mergedSettings,
+      backups: [],
+      aiHistory: [],
+      selectedSceneId: firstId,
+      showImport: false,
+      tab: "write",
+      textMetrics: null,
+      ...computeDerived(data.scenes, data.manuscripts, firstId),
+    });
   },
 
   createProject: () => set((s) => {


### PR DESCRIPTION
## Summary
- **YUY-38** 取り込み時に「新規プロジェクト / 現在に追加 / 現在を置き換え」を選択できるように
- **YUY-43** zip ファイルを取り込みファイルとして有効化

## 変更内容

### YUY-38
Preview ステップに 3 択のインポートモード選択 UI を追加。

| モード | 動作 |
|---|---|
| **新規プロジェクト**（デフォルト） | 現在のプロジェクトを保持したまま新規作成 |
| **現在に追加** | 末尾にシーンを追加（設定・タイトル変更なし） |
| **現在を置き換え** | バックアップ後に全置き換え（従来の動作） |

「追加」モード選択時はキャラ・世界観フィールドを非表示にしてシンプルな UI に。  
`appendToProject` / `createProjectFromImport` アクションをストアに追加。

### YUY-43
`fflate`（~5KB、動的インポート）を使って zip 展開に対応。  
- zip 内の `.md` / `.txt` を名前順に全展開・結合して解析  
- UTF-8 BOM / UTF-8 / Shift-JIS のエンコード自動検出を zip 内ファイルにも適用  
- `__MACOSX` 等のメタファイルは除外  

## Fixes
- Closes [YUY-38](https://linear.app/yuyuiklala/issue/YUY-38)
- Closes [YUY-43](https://linear.app/yuyuiklala/issue/YUY-43)

## Test plan
- [ ] .md / .txt のインポートで 3 モードが動作することを確認
- [ ] 「新規プロジェクト」で本棚に追加されることを確認
- [ ] 「現在に追加」でシーンが末尾に追加され設定が変わらないことを確認
- [ ] 「現在を置き換え」でバックアップが生成されることを確認
- [ ] .zip ファイルをドロップ / 選択してインポートできることを確認
- [ ] zip 内の複数 .md が結合されてシーン解析されることを確認
- [ ] 全 64 テスト通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)