### PR TITLE
YUY-39 テーマ拡張時に本文・世界観・キャラ文脈を反映

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { statusColors } from "../../constants";
 import { useStudio } from "../../contexts/StudioContext";
+import { buildSettingExpansionPrompt } from "../../utils/aiPrompts";
 import { AiPanel } from "../ai/AiPanel";
 import type {
   SceneDraft, SidebarTabKey, TabKey, Scene, AiHistoryItem
@@ -369,21 +370,29 @@ export const Sidebar: React.FC = () => {
                 onChange={e => setSettings({ ...settings, [settingsTab]: e.target.value })}
                 style={{ width: "100%", minHeight: 80, background: "#070a14", border: "1px solid #1a2535", color: "#8ab0cc", fontFamily: "inherit", fontSize: 11, lineHeight: 1.8, padding: "6px 8px", resize: "vertical", outline: "none", borderRadius: 4, boxSizing: "border-box" }}
               />
-              <AiPanel
-                label="AIで拡張"
-                compact
-                result={aiResults.worldExpand || ""}
-                onResult={t => {
-                  setAiResults(r => ({ ...r, worldExpand: t }));
-                  if (t) addAiHistory("世界観拡張", t);
-                }}
-                onLoading={v => setAiLoading(l => ({ ...l, worldExpand: v }))}
-                loading={aiLoading.worldExpand}
-                error={aiErrors.worldExpand}
-                onError={t => setAiErrors(e => ({ ...e, worldExpand: t }))}
-                prompt={`以下の創作設定メモを読んで、含意・伏線の可能性・派生しうる要素・見落とされがちな矛盾を簡潔に指摘してください。箇条書きで3〜5点。\n\n【${settingsTab === "world" ? "世界観" : settingsTab === "characters" ? "キャラクター" : "テーマ"}】\n${settings[settingsTab]}`}
-                onAppend={text => setSettings(prev => ({ ...prev, [settingsTab]: prev[settingsTab] + "\n\n---AI拡張---\n" + text }))}
-              />
+              {(() => {
+                const tabKeyMap = { world: "worldExpand", characters: "characterExpand", theme: "themeExpand" } as const;
+                const tabLabelMap = { world: "世界観", characters: "キャラクター", theme: "テーマ" } as const;
+                const resultKey = tabKeyMap[settingsTab];
+                const tabLabel = tabLabelMap[settingsTab];
+                return (
+                  <AiPanel
+                    label="AIで拡張"
+                    compact
+                    result={aiResults[resultKey] || ""}
+                    onResult={t => {
+                      setAiResults(r => ({ ...r, [resultKey]: t }));
+                      if (t) addAiHistory(`${tabLabel}拡張`, t);
+                    }}
+                    onLoading={v => setAiLoading(l => ({ ...l, [resultKey]: v }))}
+                    loading={aiLoading[resultKey]}
+                    error={aiErrors[resultKey]}
+                    onError={t => setAiErrors(e => ({ ...e, [resultKey]: t }))}
+                    prompt={buildSettingExpansionPrompt(settingsTab, settings, manuscriptText)}
+                    onAppend={text => setSettings(prev => ({ ...prev, [settingsTab]: prev[settingsTab] + "\n\n---AI拡張---\n" + text }))}
+                  />
+                );
+              })()}
             </div>
           )}
           {sidebarTab === "prefs" && (

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { AiPanel } from "../ai/AiPanel";
 import { useStudio } from "../../contexts/StudioContext";
+import { buildSettingExpansionPrompt } from "../../utils/aiPrompts";
 
 export const SettingsView: React.FC = () => {
   const {
     settings, setSettings, settingsTab, setSettingsTab,
     aiResults, setAiResults, aiErrors, setAiErrors,
-    aiLoading, setAiLoading, addAiHistory
+    aiLoading, setAiLoading, addAiHistory, manuscriptText
   } = useStudio();
 
   return (
@@ -37,7 +38,7 @@ export const SettingsView: React.FC = () => {
             loading={aiLoading[resultKey]}
             error={aiErrors[resultKey]}
             onError={t => setAiErrors(e => ({ ...e, [resultKey]: t }))}
-            prompt={`以下の創作設定メモを読んで、含意・伏線の可能性・派生しうる要素・見落とされがちな矛盾を簡潔に指摘してください。箇条書きで3〜5点。\n\n【${tabLabel}】\n${settings[settingsTab]}`}
+            prompt={buildSettingExpansionPrompt(settingsTab, settings, manuscriptText)}
             onAppend={text => setSettings(prev => ({ ...prev, [settingsTab]: prev[settingsTab] + "\n\n---AI拡張---\n" + text }))}
           />
         );

--- a/src/utils/aiPrompts.ts
+++ b/src/utils/aiPrompts.ts
@@ -1,0 +1,27 @@
+import type { Settings } from "../types";
+
+const MANUSCRIPT_CONTEXT_LIMIT = 1200;
+
+export function buildSettingExpansionPrompt(
+  settingsTab: "world" | "characters" | "theme",
+  settings: Settings,
+  manuscriptText: string,
+): string {
+  const tabLabel = settingsTab === "world" ? "世界観" : settingsTab === "characters" ? "キャラクター" : "テーマ";
+  const targetText = settings[settingsTab];
+
+  if (settingsTab === "theme") {
+    const manuscriptContext = manuscriptText.slice(-MANUSCRIPT_CONTEXT_LIMIT);
+    return [
+      "あなたは小説のテーマ設計アシスタントです。以下の本文・世界観・キャラクター設定をもとに、既存テーマから読み取れる含意を類推してください。", 
+      "本文の流れと矛盾しないことを最優先し、テーマを深める観点で提案してください。箇条書きで3〜5点。",
+      "",
+      `【テーマ】\n${targetText}`,
+      `【世界観】\n${settings.world}`,
+      `【キャラクター】\n${settings.characters}`,
+      `【本文（末尾${MANUSCRIPT_CONTEXT_LIMIT}字）】\n${manuscriptContext}`,
+    ].join("\n\n");
+  }
+
+  return `以下の創作設定メモを読んで、含意・伏線の可能性・派生しうる要素・見落とされがちな矛盾を簡潔に指摘してください。箇条書きで3〜5点。\n\n【${tabLabel}】\n${targetText}`;
+}


### PR DESCRIPTION
### Motivation
- 要件 YUY-39 に従い、テーマのAI拡張時に本文・世界観・キャラクターの文脈を参照して類推できるようにするための変更です。 
- プロンプト生成ロジックを共通化して `SettingsView` と `Sidebar` の両方で同じ振る舞いにするために抽出しました。 
- Sidebar の設定AI拡張でタブごとの結果キー・履歴ラベルを正しく扱うように修正します。 

### Description
- 追加: `src/utils/aiPrompts.ts` を新規作成し、`buildSettingExpansionPrompt` を実装してテーマタブ時に本文（末尾1200字）・世界観・キャラ情報を含む専用プロンプトを生成します. 
- 変更: `src/components/views/SettingsView.tsx` を更新して `buildSettingExpansionPrompt` を使用し、`manuscriptText` を渡すようにしました. 
- 変更: `src/components/layout/Sidebar.tsx` を更新して `buildSettingExpansionPrompt` を使用するようにし、結果ストアキーをタブ連動（`worldExpand`/`characterExpand`/`themeExpand`）に切り替え、履歴ラベルをタブ名に応じて付与するようにしました. 

### Testing
- 実行: `npm run lint` — 既存の別ファイル起因の ESLint エラー（`AiAssistant.tsx` の hooks/empty-block 等）により失敗しました. 
- 実行: `npm run test:run` — `vitest` 実行で大部分のテストは通過したものの、`App.test.tsx` スイートが `fflate` の解決失敗により失敗しました（8 suite pass / 1 suite fail）。 
- 実行: `npm run typecheck` — `tsc --noEmit` が `Cannot find module 'fflate'` により失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b9831b88832384678fb99cd83aa9)