### PR TITLE
Clarify header project shelf as project switcher

### DIFF
--- a/src/__tests__/Header.test.tsx
+++ b/src/__tests__/Header.test.tsx
@@ -44,4 +44,29 @@ describe("Header", () => {
     fireEvent.click(title);
     expect(setEditingTitle).toHaveBeenCalledWith(true);
   });
+
+  test("shows explicit project switcher label on shelf button", () => {
+    (useStudio as any).mockReturnValue({
+      projectTitle: "Project A",
+      setProjectTitle: vi.fn(),
+      editingTitle: false,
+      setEditingTitle: vi.fn(),
+      saveStatus: "saved",
+      lastSavedTime: null,
+      scenes: [],
+      settings: { world: "", characters: "", theme: "" },
+      manuscripts: {},
+      saveWithBackup: vi.fn(),
+      setShowBackups: vi.fn(),
+      setShowImport: vi.fn(),
+      setShowExport: vi.fn(),
+      setShowProjectShelf: vi.fn(),
+    });
+
+    render(<Header />);
+
+    expect(screen.getByRole("button", { name: "プロジェクト切替を開く" })).toBeInTheDocument();
+    expect(screen.getByText("プロジェクト")).toBeInTheDocument();
+    expect(screen.getByText("切替")).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,17 +17,24 @@ export const Header: React.FC = () => {
         {/* アイコン */}
         <button
           onClick={() => setShowProjectShelf(true)}
-          title="本棚を開く"
-          style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, flexShrink: 0, border: "none", background: "transparent", padding: 0, cursor: "pointer" }}
+          title="プロジェクト切替を開く"
+          aria-label="プロジェクト切替を開く"
+          style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0, border: "1px solid #1e2d42", borderRadius: 6, background: "rgba(30,45,66,0.2)", padding: "3px 6px", cursor: "pointer" }}
         >
-          <svg width="24" height="24" viewBox="0 0 28 28" fill="none">
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+            <svg width="24" height="24" viewBox="0 0 28 28" fill="none">
             <rect x="4.5" y="4.5" width="4" height="19" rx="0.8" stroke="#4a6fa5" strokeWidth="1.2"/>
             <rect x="9.8" y="5.4" width="3.6" height="18.1" rx="0.8" stroke="#3d5d8b" strokeWidth="1.2"/>
             <rect x="14.4" y="4.1" width="4.4" height="19.4" rx="0.8" stroke="#5f7fae" strokeWidth="1.2"/>
             <rect x="19.8" y="6" width="3.7" height="17.5" rx="0.8" stroke="#2f4a70" strokeWidth="1.2"/>
             <line x1="3.5" y1="23.5" x2="24.5" y2="23.5" stroke="#1e3050" strokeWidth="1.2"/>
-          </svg>
-          <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textTransform: "lowercase", whiteSpace: "nowrap" }}>minato ws</div>
+            </svg>
+            <div style={{ fontSize: 7, letterSpacing: 1.5, color: "#1e3050", textTransform: "lowercase", whiteSpace: "nowrap" }}>minato ws</div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 1 }}>
+            <span style={{ fontSize: 9, color: "#6f8db5", letterSpacing: 0.6, whiteSpace: "nowrap" }}>プロジェクト</span>
+            <span style={{ fontSize: 11, color: "#9cb5d0", whiteSpace: "nowrap" }}>切替</span>
+          </div>
         </button>
         {/* タイトル */}
         {editingTitle ? (


### PR DESCRIPTION
### Motivation
- The top-left bookshelf icon was ambiguous as a project switcher (see issue YUY-46), so the control needs a clearer label and affordance. 
- Improve discoverability and accessibility by providing visible text and an accessible name for screen readers.

### Description
- Updated the header shelf button in `src/components/layout/Header.tsx` to change the tooltip text to `プロジェクト切替を開く` and add `aria-label="プロジェクト切替を開く"`.
- Added visible Japanese label text (`プロジェクト` / `切替`) next to the bookshelf icon and adjusted button styling (border, background, padding, spacing) to increase affordance.
- Reworked the internal markup to wrap the icon and label in simple `div`s for layout clarity.
- Added a unit test in `src/__tests__/Header.test.tsx` that asserts the shelf button is reachable by role/name and that the label texts are rendered.

### Testing
- Ran `npm test -- --run src/__tests__/Header.test.tsx`, which passed (2 tests, both green).
- Attempted to start the dev server with `npm run dev`, but Vite reported an unresolved import for `fflate` and startup could not complete.
- Attempted `npm i fflate`, but package installation failed due to registry access returning `403 Forbidden`, so full local runtime verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bb48f63c8323b30f72f4e26a9d3c)