### PR TITLE
fix(YUY-56): 縦スクロール→横スクロール変換をwindow.scrollByに修正

### DIFF
--- a/src/components/editor/VerticalEditor.tsx
+++ b/src/components/editor/VerticalEditor.tsx
@@ -93,11 +93,11 @@ body { display:flex; align-items:stretch; padding:20px; }
       editor.style.lineHeight = String(e.data.lineHeight);
     }
   });
-  // YUY-56: マウス縦スクロールを横スクロールに変換
+  // YUY-56: マウス縦スクロールを横スクロールに変換（trackpadのdeltaXはそのまま通す）
   document.addEventListener('wheel', (e) => {
-    if (e.deltaY !== 0) {
+    if (e.deltaY !== 0 && e.deltaX === 0) {
       e.preventDefault();
-      document.documentElement.scrollLeft += e.deltaY;
+      window.scrollBy(e.deltaY, 0);
     }
   }, { passive: false });
 </script></body></html>`;


### PR DESCRIPTION
documentElement.scrollLeftではスクロール対象が変わる場合があるため
window.scrollBy(deltaY, 0)に変更。trackpadのdeltaXは素通しする。