### PR TITLE
fix: complete YUY-59/YUY-60/YUY-56 and optimize YUY-63 startup load

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -15,7 +15,7 @@ vi.mock("../supabase", () => ({
   },
 }));
 
-import { storageGet, storageSet } from "../utils/storage";
+import { storageGet, storageGetMany, storageSet } from "../utils/storage";
 
 describe("storageGet", () => {
   beforeEach(() => {
@@ -94,5 +94,30 @@ describe("storageSet", () => {
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!);
     expect(parsed.value).toBe("");
+  });
+});
+
+describe("storageGetMany", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns local values for multiple keys in one call", async () => {
+    await storageSet("minato:title", "作品A");
+    await storageSet("minato:sidebarFloat", false);
+    await storageSet("minato:sidebarWidth", 240);
+
+    const result = await storageGetMany([
+      "minato:title",
+      "minato:sidebarFloat",
+      "minato:sidebarWidth",
+      "missing:key",
+    ]);
+
+    expect(result["minato:title"]).toBe("作品A");
+    expect(result["minato:sidebarFloat"]).toBe(false);
+    expect(result["minato:sidebarWidth"]).toBe(240);
+    expect(result["missing:key"]).toBeNull();
   });
 });

--- a/src/components/editor/VerticalEditor.tsx
+++ b/src/components/editor/VerticalEditor.tsx
@@ -93,12 +93,14 @@ body { display:flex; align-items:stretch; padding:20px; }
       editor.style.lineHeight = String(e.data.lineHeight);
     }
   });
-  // YUY-56: マウス縦スクロールを横スクロールに変換（trackpadのdeltaXはそのまま通す）
+  // YUY-56: マウス縦スクロールを横スクロールへ変換（trackpadの横スクロールは維持）
   document.addEventListener('wheel', (e) => {
-    if (e.deltaY !== 0 && e.deltaX === 0) {
-      e.preventDefault();
-      window.scrollBy(e.deltaY, 0);
-    }
+    if (e.ctrlKey) return; // pinch-zoom gestures
+    if (e.deltaY === 0 || e.deltaX !== 0) return;
+    const root = document.scrollingElement || document.documentElement;
+    const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? window.innerWidth : 1;
+    root.scrollLeft += e.deltaY * unit;
+    e.preventDefault();
   }, { passive: false });
 </script></body></html>`;
   }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -84,18 +84,18 @@ export const Header: React.FC = () => {
           </div>
         )}
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <div className="header-actions" style={{ display: "flex", alignItems: "center", gap: 10 }}>
         <div className="header-hide-sm" style={{ fontSize: 10, color: saveStatus === "saved" ? "#2a4060" : saveStatus === "saving" ? "#4a6fa5" : saveStatus === "offline" ? "#8a6b2d" : "#e05555" }}>
           {saveStatus === "saving" ? "保存中…" :
            saveStatus === "offline" ? "☁ オフライン保存" :
            saveStatus === "error" ? "⚠ エラー" :
            lastSavedTime ? `保存: ${lastSavedTime.getHours()}:${String(lastSavedTime.getMinutes()).padStart(2,"0")}` : "✓"}
         </div>
-        <button onClick={() => saveWithBackup(scenes, settings, manuscripts, projectTitle)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>保存</button>
-        <button onClick={() => setShowBackups(true)} className="header-hide-sm" style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>履歴</button>
+        <button className="header-priority-btn" onClick={() => saveWithBackup(scenes, settings, manuscripts, projectTitle)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>保存</button>
+        <button className="header-priority-btn" onClick={() => setShowBackups(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>履歴</button>
         <button onClick={() => setShowImport(true)} className="header-hide-sm" style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>取込</button>
-        <button onClick={() => setShowExport(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>出力</button>
-        {/* スマホのみ表示: 履歴・取込をまとめた「…」メニュー */}
+        <button onClick={() => setShowExport(true)} className="header-hide-sm" style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>出力</button>
+        {/* スマホのみ表示: 補助操作をまとめた「…」メニュー */}
         <div ref={moreRef} className="header-show-sm" style={{ position: "relative" }}>
           <button
             onClick={() => setMoreOpen(v => !v)}
@@ -103,15 +103,20 @@ export const Header: React.FC = () => {
           >…</button>
           {moreOpen && (
             <div style={{ position: "absolute", top: "calc(100% + 6px)", right: 0, background: "#0a0f1a", border: "1px solid #1e2d42", borderRadius: 6, display: "flex", flexDirection: "column", gap: 4, padding: 8, zIndex: 200, minWidth: 80 }}>
-              <button onClick={() => { setShowBackups(true); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>履歴</button>
               <button onClick={() => { setShowImport(true); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>取込</button>
+              <button onClick={() => { setShowExport(true); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>出力</button>
+              {user ? (
+                <button onClick={() => { supabase.auth.signOut(); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>退出</button>
+              ) : (
+                <button onClick={() => { supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } }); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#7ab3e0", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>ログイン</button>
+              )}
             </div>
           )}
         </div>
         {user ? (
-          <button onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>退出</button>
+          <button className="header-hide-sm" onClick={() => supabase.auth.signOut()} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>退出</button>
         ) : (
-          <button onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>ログイン</button>
+          <button className="header-hide-sm" onClick={() => supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: window.location.origin } })} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>ログイン</button>
         )}
       </div>
     </header>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -199,8 +199,8 @@ export const Sidebar: React.FC = () => {
             {([["write","執筆"],["structure","構成"],["settings","世界観"],["prefs","環境"],["ai","AI"]] as [SidebarTabKey, string][]).map(([key, label]) => (
               <button key={key} onClick={() => {
                 setSidebarTab(key);
-                // In fixed (non-float) mode, main view stays on write
-                if (sidebarFloat) setTab(key as TabKey);
+                // YUY-59: keep main pane unchanged while sidebar is floating
+                if (!sidebarFloat) setTab(key as TabKey);
               }} style={{
                 flex: 1, padding: "8px 0", background: "transparent", border: "none",
                 borderBottom: sidebarTab === key ? "2px solid #4a6fa5" : "2px solid transparent",
@@ -511,7 +511,10 @@ export const Sidebar: React.FC = () => {
         </>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 4 }}>
-          <button onClick={() => { setSidebarOpen(true); setTab("write"); }} style={{ padding: "8px 0", width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>▶</button>
+          <button onClick={() => {
+            setSidebarOpen(true);
+            if (!sidebarFloat) setTab("write");
+          }} style={{ padding: "8px 0", width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>▶</button>
           {[
             { key: "write", label: "執筆" },
             { key: "structure", label: "構成" },
@@ -520,9 +523,9 @@ export const Sidebar: React.FC = () => {
             { key: "ai", label: "AI履歴" },
           ].map(({ key, label }) => (
             <button key={key} onClick={() => {
-              setTab(key as TabKey);
               setSidebarTab(key as SidebarTabKey);
-              if (sidebarFloat) setSidebarOpen(false);
+              if (sidebarFloat) setSidebarOpen(true);
+              else setTab(key as TabKey);
             }} style={{
               padding: "14px 0", width: "100%", border: "none",
               borderBottom: "1px solid #0e1520",
@@ -542,8 +545,9 @@ export const Sidebar: React.FC = () => {
                 <div
                   key={item.id}
                   onClick={() => {
-                    setTab("ai");
-                    if (sidebarFloat) setSidebarOpen(false);
+                    setSidebarTab("ai");
+                    if (sidebarFloat) setSidebarOpen(true);
+                    else setTab("ai");
                     if (!expandedIds.includes(item.id)) toggleExpand(item.id);
                   }}
                   title={`${item.label}: ${item.content.substring(0, 20)}...`}

--- a/src/contexts/StudioContext.tsx
+++ b/src/contexts/StudioContext.tsx
@@ -8,7 +8,7 @@
  */
 import React, { useEffect, useRef } from "react";
 import type { User } from "@supabase/supabase-js";
-import { storageGet, storageSet } from "../utils/storage";
+import { storageGetMany, storageSet } from "../utils/storage";
 import type { Scene, Settings, Manuscripts, EditorSettings, AiHistoryItem, Backup, ProjectRecord } from "../types";
 import { useStudioStore } from "../stores/useStudioStore";
 import { analyzeText } from "../utils/textAnalyzer";
@@ -32,22 +32,36 @@ export function StudioProvider({ children, user }: { children: React.ReactNode; 
   useEffect(() => {
     (async () => {
       store.setLoaded(false);
-      const [sc, st, ms, pt, bk, es, ah, ab, sf, sw, af, apw, projects, activeProjectId] = await Promise.all([
-        storageGet<Scene[]>("minato:scenes"),
-        storageGet<Settings>("minato:settings"),
-        storageGet<Manuscripts>("minato:manuscripts"),
-        storageGet<string>("minato:title"),
-        storageGet<Backup[]>("minato:backups"),
-        storageGet<EditorSettings>("minato:editorSettings"),
-        storageGet<AiHistoryItem[]>("minato:aiHistory"),
-        storageGet<Backup[]>("minato:autoBackups"),
-        storageGet<boolean>("minato:sidebarFloat"),
-        storageGet<number>("minato:sidebarWidth"),
-        storageGet<boolean>("minato:aiFloat"),
-        storageGet<number>("minato:aiPanelWidth"),
-        storageGet<ProjectRecord[]>("minato:projects"),
-        storageGet<string>("minato:activeProjectId"),
+      const loaded = await storageGetMany([
+        "minato:scenes",
+        "minato:settings",
+        "minato:manuscripts",
+        "minato:title",
+        "minato:backups",
+        "minato:editorSettings",
+        "minato:aiHistory",
+        "minato:autoBackups",
+        "minato:sidebarFloat",
+        "minato:sidebarWidth",
+        "minato:aiFloat",
+        "minato:aiPanelWidth",
+        "minato:projects",
+        "minato:activeProjectId",
       ]);
+      const sc = loaded["minato:scenes"] as Scene[] | null;
+      const st = loaded["minato:settings"] as Settings | null;
+      const ms = loaded["minato:manuscripts"] as Manuscripts | null;
+      const pt = loaded["minato:title"] as string | null;
+      const bk = loaded["minato:backups"] as Backup[] | null;
+      const es = loaded["minato:editorSettings"] as EditorSettings | null;
+      const ah = loaded["minato:aiHistory"] as AiHistoryItem[] | null;
+      const ab = loaded["minato:autoBackups"] as Backup[] | null;
+      const sf = loaded["minato:sidebarFloat"] as boolean | null;
+      const sw = loaded["minato:sidebarWidth"] as number | null;
+      const af = loaded["minato:aiFloat"] as boolean | null;
+      const apw = loaded["minato:aiPanelWidth"] as number | null;
+      const projects = loaded["minato:projects"] as ProjectRecord[] | null;
+      const activeProjectId = loaded["minato:activeProjectId"] as string | null;
       const resolvedScenes = sc ?? store.scenes;
       const resolvedSettings = st ?? store.settings;
       const resolvedManuscripts = ms ?? store.manuscripts;

--- a/src/index.css
+++ b/src/index.css
@@ -26,4 +26,6 @@
 @media (max-width: 540px) {
   .header-hide-sm { display: none !important; }
   .header-show-sm { display: block !important; }
+  .header-actions { gap: 6px !important; }
+  .header-priority-btn { padding: 4px 8px !important; font-size: 10px !important; }
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -5,9 +5,13 @@ interface StoredData<T> {
   updated_at: string;
 }
 
+function readLocal<T>(key: string): StoredData<T> | null {
+  const raw = localStorage.getItem(key);
+  return raw ? JSON.parse(raw) as StoredData<T> : null;
+}
+
 export async function storageGet<T = unknown>(key: string): Promise<T | null> {
-  const localRaw = localStorage.getItem(key);
-  const localData: StoredData<T> | null = localRaw ? JSON.parse(localRaw) : null;
+  const localData = readLocal<T>(key);
 
   try {
     const { data: { user } } = await supabase.auth.getUser();
@@ -33,6 +37,46 @@ export async function storageGet<T = unknown>(key: string): Promise<T | null> {
   } catch {
     return localData != null ? localData.value : null;
   }
+}
+
+export async function storageGetMany(keys: string[]): Promise<Record<string, unknown>> {
+  const uniqueKeys = Array.from(new Set(keys));
+  const localMap = new Map<string, StoredData<unknown> | null>();
+  const result: Record<string, unknown> = {};
+
+  for (const key of uniqueKeys) {
+    const localData = readLocal<unknown>(key);
+    localMap.set(key, localData);
+    result[key] = localData != null ? localData.value : null;
+  }
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user || uniqueKeys.length === 0) return result;
+
+    const { data, error } = await supabase
+      .from("minato_data")
+      .select("key, value, updated_at")
+      .eq("user_id", user.id)
+      .in("key", uniqueKeys);
+
+    if (error || !data) return result;
+
+    for (const row of data as Array<{ key: string; value: unknown; updated_at: string }>) {
+      const localData = localMap.get(row.key);
+      const remoteData: StoredData<unknown> = { value: row.value, updated_at: row.updated_at };
+      if (!localData || new Date(remoteData.updated_at) > new Date(localData.updated_at)) {
+        localStorage.setItem(row.key, JSON.stringify(remoteData));
+        result[row.key] = remoteData.value;
+      } else {
+        result[row.key] = localData.value;
+      }
+    }
+  } catch {
+    // localStorage fallback already populated in result
+  }
+
+  return result;
 }
 
 export async function storageSet(key: string, value: unknown): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Fix YUY-59: keep main pane unchanged while sidebar is floating
- Fix YUY-60: keep Save/History visible in compact header mode; move secondary actions into overflow menu
- Fix YUY-56: stabilize vertical-editor wheel behavior by converting vertical wheel to horizontal scroll via scrollLeft with deltaMode normalization
- Improve YUY-63: reduce startup loading overhead by batching initial storage reads with new storageGetMany

## Files Changed
- src/components/layout/Sidebar.tsx
- src/components/layout/Header.tsx
- src/components/editor/VerticalEditor.tsx
- src/utils/storage.ts
- src/contexts/StudioContext.tsx
- src/__tests__/storage.test.ts
- src/index.css

## Validation
- npm run test:run -- src/__tests__/Header.test.tsx (pass)
- npm run test:run -- src/__tests__/App.test.tsx (pass)
- npm run test:run -- src/__tests__/storage.test.ts src/__tests__/App.test.tsx (pass)
- Note: existing unrelated test failure remains in src/__tests__/StudioContext.test.tsx (expected export filename string differs: .minato-project.json vs .gz).