### PR TITLE
YUY-72/YUY-74: フルスクリーンとUndo/Redo実装

### DIFF
--- a/src/__tests__/useStudioStore.history.test.ts
+++ b/src/__tests__/useStudioStore.history.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Scene } from "../types";
+import { resetStudioStore, useStudioStore } from "../stores/useStudioStore";
+
+const scene: Scene = {
+  id: 1,
+  chapter: "第一章",
+  title: "導入",
+  synopsis: "",
+  status: "empty",
+};
+
+describe("useStudioStore history", () => {
+  beforeEach(() => {
+    resetStudioStore();
+  });
+
+  it("undo/redo manuscript changes", () => {
+    const store = useStudioStore.getState();
+    store.setScenes([scene]);
+    store.handleSceneSelect(scene);
+    store.handleManuscriptChange("A");
+    store.handleManuscriptChange("AB");
+
+    expect(useStudioStore.getState().manuscriptText).toBe("AB");
+
+    useStudioStore.getState().undo();
+    expect(useStudioStore.getState().manuscriptText).toBe("A");
+
+    useStudioStore.getState().redo();
+    expect(useStudioStore.getState().manuscriptText).toBe("AB");
+  });
+
+  it("undo/redo scene status changes", () => {
+    const store = useStudioStore.getState();
+    store.setScenes([scene]);
+    store.handleStatusChange(scene.id, "draft");
+    expect(useStudioStore.getState().scenes[0]?.status).toBe("draft");
+
+    useStudioStore.getState().undo();
+    expect(useStudioStore.getState().scenes[0]?.status).toBe("empty");
+
+    useStudioStore.getState().redo();
+    expect(useStudioStore.getState().scenes[0]?.status).toBe("draft");
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ export const Header: React.FC = () => {
   } = useStudio();
   const hasProjectTitle = projectTitle.trim().length > 0;
   const [moreOpen, setMoreOpen] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(Boolean(document.fullscreenElement));
   const moreRef = useRef<HTMLDivElement>(null);
 
   // 外側クリックでメニューを閉じる
@@ -24,6 +25,24 @@ export const Header: React.FC = () => {
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [moreOpen]);
+
+  useEffect(() => {
+    const onFullscreenChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async () => {
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch {
+      alert("フルスクリーンに切り替えできませんでした。");
+    }
+  };
 
   return (
     <header style={{ borderBottom: "1px solid #1e2d42", padding: "0 16px", display: "flex", alignItems: "center", justifyContent: "space-between", background: "rgba(10,14,26,0.95)", position: "sticky", top: 0, zIndex: 100, height: 44 }}>
@@ -93,6 +112,7 @@ export const Header: React.FC = () => {
         </div>
         <button className="header-priority-btn" onClick={() => saveWithBackup(scenes, settings, manuscripts, projectTitle)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #2a4060", background: "rgba(74,111,165,0.1)", color: "#4a6fa5", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>保存</button>
         <button className="header-priority-btn" onClick={() => setShowBackups(true)} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>履歴</button>
+        <button className="header-priority-btn" onClick={toggleFullscreen} style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: isFullscreen ? "rgba(74,111,165,0.12)" : "transparent", color: isFullscreen ? "#7ab3e0" : "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>{isFullscreen ? "全画面解除" : "全画面"}</button>
         <button onClick={() => setShowImport(true)} className="header-hide-sm" style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>取込</button>
         <button onClick={() => setShowExport(true)} className="header-hide-sm" style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#3a5570", cursor: "pointer", fontSize: 11, fontFamily: "inherit" }}>出力</button>
         {/* スマホのみ表示: 補助操作をまとめた「…」メニュー */}
@@ -103,6 +123,7 @@ export const Header: React.FC = () => {
           >…</button>
           {moreOpen && (
             <div style={{ position: "absolute", top: "calc(100% + 6px)", right: 0, background: "#0a0f1a", border: "1px solid #1e2d42", borderRadius: 6, display: "flex", flexDirection: "column", gap: 4, padding: 8, zIndex: 200, minWidth: 80 }}>
+              <button onClick={() => { toggleFullscreen(); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>{isFullscreen ? "全画面解除" : "全画面"}</button>
               <button onClick={() => { setShowImport(true); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>取込</button>
               <button onClick={() => { setShowExport(true); setMoreOpen(false); }} style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #1e2d42", background: "transparent", color: "#c8d8e8", cursor: "pointer", fontSize: 12, fontFamily: "inherit", textAlign: "left" }}>出力</button>
               {user ? (

--- a/src/components/views/WriteView.tsx
+++ b/src/components/views/WriteView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { VerticalEditor } from "../editor/VerticalEditor";
 import { AiPanel } from "../ai/AiPanel";
 import { statusColors, statusLabels } from "../../constants";
@@ -13,9 +13,38 @@ export const WriteView: React.FC = () => {
     handleDeleteScene, manuscriptText, handleManuscriptChange,
     editorSettings, handleSceneSelect, wordCount, textMetrics,
     aiResults, setAiResults, aiErrors, setAiErrors,
-    aiLoading, setAiLoading, settings, addAiHistory
+    aiLoading, setAiLoading, settings, addAiHistory,
+    historyPast, historyFuture, undo, redo
   } = useStudio();
   const [footerOpen, setFooterOpen] = useState(true);
+  const canUndo = historyPast.length > 0;
+  const canRedo = historyFuture.length > 0;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+      if (e.key.toLowerCase() === "z" && e.shiftKey) {
+        if (!canRedo) return;
+        e.preventDefault();
+        redo();
+        return;
+      }
+      if (e.key.toLowerCase() === "z") {
+        if (!canUndo) return;
+        e.preventDefault();
+        undo();
+        return;
+      }
+      if (e.key.toLowerCase() === "y") {
+        if (!canRedo) return;
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [canRedo, canUndo, redo, undo]);
 
   if (!selectedScene) {
     return (
@@ -66,6 +95,42 @@ export const WriteView: React.FC = () => {
             {(["empty", "draft", "done"] as const).map(s => (
               <button key={s} onClick={() => handleStatusChange(selectedScene.id, s)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: selectedScene.status === s ? statusColors[s] : "#1e2d42", background: selectedScene.status === s ? `${statusColors[s]}22` : "transparent", color: selectedScene.status === s ? statusColors[s] : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>{statusLabels[s]}</button>
             ))}
+            <button
+              onClick={undo}
+              disabled={!canUndo}
+              title="元に戻す (Ctrl/Cmd+Z)"
+              style={{
+                padding: "4px 10px",
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: canUndo ? "#2a4060" : "#0f1725",
+                background: canUndo ? "rgba(74,111,165,0.1)" : "transparent",
+                color: canUndo ? "#5b7ea7" : "#1a2535",
+                cursor: canUndo ? "pointer" : "default",
+                fontSize: 10,
+                fontFamily: "inherit",
+              }}
+            >
+              Undo
+            </button>
+            <button
+              onClick={redo}
+              disabled={!canRedo}
+              title="やり直し (Ctrl/Cmd+Shift+Z / Ctrl/Cmd+Y)"
+              style={{
+                padding: "4px 10px",
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: canRedo ? "#2a4060" : "#0f1725",
+                background: canRedo ? "rgba(74,111,165,0.1)" : "transparent",
+                color: canRedo ? "#5b7ea7" : "#1a2535",
+                cursor: canRedo ? "pointer" : "default",
+                fontSize: 10,
+                fontFamily: "inherit",
+              }}
+            >
+              Redo
+            </button>
             <button onClick={() => setVerticalPreview(!verticalPreview)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid", borderColor: verticalPreview ? "#4a6fa5" : "#1e2d42", background: verticalPreview ? "rgba(74,111,165,0.15)" : "transparent", color: verticalPreview ? "#7ab3e0" : "#2a4060", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>縦組</button>
             <button onClick={() => handleDeleteScene(selectedScene.id)} style={{ padding: "4px 10px", borderRadius: 3, border: "1px solid #1e2d42", background: "transparent", color: "#3a2020", cursor: "pointer", fontSize: 10, fontFamily: "inherit" }}>削除</button>
           </div>

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -11,6 +11,21 @@ import { storageSet } from "../utils/storage";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+const HISTORY_LIMIT = 120;
+
+type EditorSnapshot = {
+  scenes: Scene[];
+  manuscripts: Manuscripts;
+  selectedSceneId: number | null;
+};
+
+function createEditorSnapshot(state: Pick<StudioState, "scenes" | "manuscripts" | "selectedSceneId">): EditorSnapshot {
+  return {
+    scenes: state.scenes,
+    manuscripts: state.manuscripts,
+    selectedSceneId: state.selectedSceneId,
+  };
+}
 
 function computeDerived(
   scenes: Scene[],
@@ -90,6 +105,9 @@ export interface StudioState {
   aiApplied: AppliedState;
   hintApplied: AppliedState;
   aiHistory: AiHistoryItem[];
+  historyPast: EditorSnapshot[];
+  historyFuture: EditorSnapshot[];
+  historyLocked: boolean;
 
   // derived (kept in store for fast access)
   selectedScene: Scene | null;
@@ -144,10 +162,13 @@ export interface StudioState {
   setHintApplied: (v: AppliedState | ((prev: AppliedState) => AppliedState)) => void;
   setAiHistory: (v: AiHistoryItem[] | ((prev: AiHistoryItem[]) => AiHistoryItem[])) => void;
   setTextMetrics: (v: TextMetrics | null) => void;
+  setHistoryLocked: (v: boolean) => void;
 
   // ---------------------------------------------------------------------------
   // Actions (business logic)
   // ---------------------------------------------------------------------------
+  undo: () => void;
+  redo: () => void;
   addAiHistory: (label: string, content: string, sceneTitle?: string, sceneId?: number) => void;
   clearAiHistory: () => void;
   handleSceneSelect: (scene: Scene) => void;
@@ -269,6 +290,9 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   aiApplied: {},
   hintApplied: {},
   aiHistory: [],
+  historyPast: [],
+  historyFuture: [],
+  historyLocked: false,
   selectedScene: null,
   manuscriptText: "",
   wordCount: 0,
@@ -286,7 +310,16 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   setSettingsTab: (v) => set({ settingsTab: v }),
   setScenes: (v) => set((s) => {
     const next = typeof v === "function" ? v(s.scenes) : v;
-    return { scenes: next, ...computeDerived(next, s.manuscripts, s.selectedSceneId) };
+    if (Object.is(next, s.scenes)) return {};
+    const update: Partial<StudioState> = {
+      scenes: next,
+      ...computeDerived(next, s.manuscripts, s.selectedSceneId),
+    };
+    if (!s.historyLocked) {
+      update.historyPast = [...s.historyPast, createEditorSnapshot(s)].slice(-HISTORY_LIMIT);
+      update.historyFuture = [];
+    }
+    return update;
   }),
   setSelectedSceneId: (v) => set((s) => ({
     selectedSceneId: v,
@@ -294,7 +327,16 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   })),
   setManuscripts: (v) => set((s) => {
     const next = typeof v === "function" ? v(s.manuscripts) : v;
-    return { manuscripts: next, ...computeDerived(s.scenes, next, s.selectedSceneId) };
+    if (Object.is(next, s.manuscripts)) return {};
+    const update: Partial<StudioState> = {
+      manuscripts: next,
+      ...computeDerived(s.scenes, next, s.selectedSceneId),
+    };
+    if (!s.historyLocked) {
+      update.historyPast = [...s.historyPast, createEditorSnapshot(s)].slice(-HISTORY_LIMIT);
+      update.historyFuture = [];
+    }
+    return update;
   }),
   setSettings: (v) => set((s) => ({ settings: typeof v === "function" ? v(s.settings) : v })),
   setProjectTitle: (v) => set((s) => ({
@@ -335,10 +377,37 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   setHintApplied: (v) => set((s) => ({ hintApplied: typeof v === "function" ? v(s.hintApplied) : v })),
   setAiHistory: (v) => set((s) => ({ aiHistory: typeof v === "function" ? v(s.aiHistory) : v })),
   setTextMetrics: (v) => set({ textMetrics: v }),
+  setHistoryLocked: (v) => set({ historyLocked: v }),
 
   // ---------------------------------------------------------------------------
   // Actions
   // ---------------------------------------------------------------------------
+  undo: () => set((s) => {
+    if (s.historyPast.length === 0) return {};
+    const prev = s.historyPast[s.historyPast.length - 1];
+    return {
+      historyPast: s.historyPast.slice(0, -1),
+      historyFuture: [createEditorSnapshot(s), ...s.historyFuture].slice(0, HISTORY_LIMIT),
+      scenes: prev.scenes,
+      manuscripts: prev.manuscripts,
+      selectedSceneId: prev.selectedSceneId,
+      ...computeDerived(prev.scenes, prev.manuscripts, prev.selectedSceneId),
+    };
+  }),
+
+  redo: () => set((s) => {
+    if (s.historyFuture.length === 0) return {};
+    const [next, ...rest] = s.historyFuture;
+    return {
+      historyPast: [...s.historyPast, createEditorSnapshot(s)].slice(-HISTORY_LIMIT),
+      historyFuture: rest,
+      scenes: next.scenes,
+      manuscripts: next.manuscripts,
+      selectedSceneId: next.selectedSceneId,
+      ...computeDerived(next.scenes, next.manuscripts, next.selectedSceneId),
+    };
+  }),
+
   addAiHistory: (label, content, sceneTitle, sceneId) => {
     if (!content.trim()) return;
     const item: AiHistoryItem = { id: Date.now(), timestamp: new Date().toISOString(), label, content, sceneTitle, sceneId };
@@ -357,16 +426,18 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   })),
 
   handleManuscriptChange: (text) => {
-    const { selectedSceneId, manuscripts, scenes } = get();
+    const { selectedSceneId, manuscripts, setManuscripts } = get();
     if (selectedSceneId === null) return;
-    const next = { ...manuscripts, [selectedSceneId]: text };
-    set({ manuscripts: next, ...computeDerived(scenes, next, selectedSceneId) });
+    if ((manuscripts[selectedSceneId] ?? "") === text) return;
+    setManuscripts({ ...manuscripts, [selectedSceneId]: text });
   },
 
-  handleStatusChange: (id, status) => set((s) => {
-    const next = s.scenes.map(sc => sc.id === id ? { ...sc, status } : sc);
-    return { scenes: next, ...computeDerived(next, s.manuscripts, s.selectedSceneId) };
-  }),
+  handleStatusChange: (id, status) => {
+    const { scenes, setScenes } = get();
+    const current = scenes.find(sc => sc.id === id);
+    if (!current || current.status === status) return;
+    setScenes(scenes.map(sc => sc.id === id ? { ...sc, status } : sc));
+  },
 
   handleAddScene: () => set((s) => {
     const scene: Scene = { ...s.newScene, id: Date.now(), status: "empty" };
@@ -375,6 +446,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       scenes: next,
       newScene: { chapter: "", title: "", synopsis: "" },
       addingScene: false,
+      historyPast: [...s.historyPast, createEditorSnapshot(s)].slice(-HISTORY_LIMIT),
+      historyFuture: [],
       ...computeDerived(next, s.manuscripts, s.selectedSceneId),
     };
   }),
@@ -393,6 +466,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       manuscripts: nextManuscripts,
       selectedSceneId: nextSelectedId,
       confirmDelete: null,
+      historyPast: [...s.historyPast, createEditorSnapshot(s)].slice(-HISTORY_LIMIT),
+      historyFuture: [],
       ...computeDerived(nextScenes, nextManuscripts, nextSelectedId),
     };
   }),
@@ -518,6 +593,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       showImport: false,
       tab: "write",
       textMetrics: null,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(newScenes, newManuscripts, firstId),
     });
@@ -573,6 +650,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       showImport: false,
       tab: "write",
       textMetrics: null,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(importedProject.scenes, importedProject.manuscripts, firstId),
     };
@@ -598,6 +677,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       showImport: false,
       tab: "write",
       textMetrics: null,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(newScenes, newManuscripts, firstNewId),
     });
@@ -651,6 +732,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       showImport: false,
       tab: "write",
       textMetrics: null,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(data.scenes, data.manuscripts, firstId),
     });
@@ -686,6 +769,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       aiHistory: [],
       selectedSceneId: null,
       showProjectShelf: false,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(initialScenes, {}, null),
     };
@@ -713,6 +798,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       aiHistory: target.aiHistory ?? [],
       selectedSceneId: firstId,
       showProjectShelf: false,
+      historyPast: [],
+      historyFuture: [],
       ...resetAiWorkspaceState(),
       ...computeDerived(target.scenes, target.manuscripts, firstId),
     };
@@ -742,6 +829,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
         backups: target.backups,
         aiHistory: target.aiHistory ?? [],
         selectedSceneId: firstId,
+        historyPast: [],
+        historyFuture: [],
         ...resetAiWorkspaceState(),
         ...computeDerived(target.scenes, target.manuscripts, firstId),
       };
@@ -832,6 +921,9 @@ export function resetStudioStore() {
     aiApplied: {},
     hintApplied: {},
     aiHistory: [],
+    historyPast: [],
+    historyFuture: [],
+    historyLocked: false,
     selectedScene: null,
     manuscriptText: "",
     wordCount: 0,


### PR DESCRIPTION
## 対応内容\n- YUY-72: ヘッダーに全画面/全画面解除ボタンを追加（モバイルの…メニューにも追加）\n- YUY-74: undo/redo履歴スタックをストアに実装（本文変更・ステータス変更・シーン追加削除を履歴化）\n- 執筆画面にUndo/Redoボタンを追加\n- キーボードショートカット対応（Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, Ctrl/Cmd+Y）\n- 履歴機能のテストを追加\n\n## 確認\n- npm run build\n- npm run test:run -- src/__tests__/useStudioStore.history.test.ts src/__tests__/Header.test.tsx\n\nCloses #164\nCloses #171