### PR TITLE
fix: JWT検証に VITE_SUPABASE_ANON_KEY をフォールバックとして使用

### DIFF
--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -5,8 +5,11 @@ let _adminClient: ReturnType<typeof createClient> | null = null;
 function getAdminClient() {
   if (!_adminClient) {
     const url = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!url || !key) throw new Error("Missing Supabase env vars");
+    // Service role key for admin ops; anon key is sufficient for auth.getUser() JWT verification
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+      ?? process.env.SUPABASE_ANON_KEY
+      ?? process.env.VITE_SUPABASE_ANON_KEY;
+    if (!url || !key) throw Object.assign(new Error("Missing Supabase env vars"), { status: 401 });
     _adminClient = createClient(url, key, { auth: { persistSession: false } });
   }
   return _adminClient;


### PR DESCRIPTION
auth.getUser(token) はアノン Key でも JWT の検証が可能。
SUPABASE_SERVICE_ROLE_KEY が Vercel に未設定の場合でも
VITE_SUPABASE_ANON_KEY（フロントエンド用として設定済み）で
認証が通るようにする。Missing Supabase env vars エラーも
401 ステータス付きに変更して明示的に伝える。

https://claude.ai/code/session_016brSczR8wFRcJHcTeoQMuL