### PR TITLE
fix: SUPABASE_SERVICE_ROLE_KEY 未設定時のレート制限・クレジットエラーを修正

### DIFF
--- a/api/_lib/credits.ts
+++ b/api/_lib/credits.ts
@@ -14,7 +14,14 @@ function getAdminClient() {
 }
 
 export async function checkAndConsumeCredit(userId: string): Promise<void> {
-  const supabase = getAdminClient();
+  let supabase: ReturnType<typeof createClient>;
+  try {
+    supabase = getAdminClient();
+  } catch {
+    // Service role key not configured — skip credit check
+    console.warn("Credit check skipped: admin client unavailable");
+    return;
+  }
   const today = new Date().toISOString().slice(0, 10);
   const thisMonth = today.slice(0, 7) + "-01";
 

--- a/api/_lib/rateLimit.ts
+++ b/api/_lib/rateLimit.ts
@@ -17,7 +17,14 @@ function getAdminClient() {
 }
 
 export async function checkRateLimit(userId: string, ipAddress: string): Promise<void> {
-  const supabase = getAdminClient();
+  let supabase: ReturnType<typeof createClient>;
+  try {
+    supabase = getAdminClient();
+  } catch {
+    // Service role key not configured — skip rate limiting
+    console.warn("Rate limit check skipped: admin client unavailable");
+    return;
+  }
   const windowStart = new Date();
   windowStart.setSeconds(0, 0);
   windowStart.setMinutes(Math.floor(windowStart.getMinutes() / WINDOW_MINUTES) * WINDOW_MINUTES);


### PR DESCRIPTION
getAdminClient() のスローを個別に catch してスキップ扱いにすることで、
サービスロールキーが Vercel に設定されていない場合でも
429 "Too many requests" エラーにならず AI 機能が利用できるようにする。

https://claude.ai/code/session_016brSczR8wFRcJHcTeoQMuL