### PR TITLE
Add opening sentence generation feature to AI assistant

### DIFF
--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { AiPanel } from "./AiPanel";
 import { HintPanel } from "./HintPanel";
 import { PolishPanel } from "./PolishPanel";
+import { OpeningPanel } from "./OpeningPanel";
 import { callAnthropic, AiError } from "../../utils/ai";
 import { useStudio } from "../../contexts/StudioContext";
 
@@ -142,6 +143,24 @@ export const AiAssistant: React.FC = () => {
               <button onClick={() => setShowSettings(false)} style={{ background: "transparent", border: "none", color: "#3a5570", cursor: "pointer", fontSize: 13, fontFamily: "inherit" }}>✕</button>
             </div>
             <div style={{ padding: 16, overflowY: "auto", flex: 1, display: "flex", flexDirection: "column", gap: 16 }}>
+              {/* 書き出し生成パネル */}
+              <OpeningPanel
+                aiMode={aiMode}
+                byokLocalKey={byokLocalKey}
+                initialWorld={settings.world}
+                initialCharacters={settings.characters}
+                result={aiResults.opening}
+                onResult={t => {
+                  setAiResults(r => ({ ...r, opening: t }));
+                  if (t) addAiHistory("書き出し生成", t, selectedScene?.title, selectedScene?.id);
+                }}
+                loading={aiLoading.opening}
+                onLoading={v => setAiLoading(l => ({ ...l, opening: v }))}
+                error={aiErrors.opening}
+                onError={t => setAiErrors(e => ({ ...e, opening: t }))}
+                onInsert={text => handleManuscriptChange(text + (manuscriptText ? "\n\n" + manuscriptText : ""))}
+                onAppend={text => handleManuscriptChange(manuscriptText + (manuscriptText ? "\n\n" : "") + text)}
+              />
               {/* 自由指示パネル */}
               <div style={{ borderBottom: "1px solid #1a2535", paddingBottom: 16 }}>
                 <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 8 }}>✦ 自由指示</div>

--- a/src/components/ai/OpeningPanel.tsx
+++ b/src/components/ai/OpeningPanel.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { callAnthropic, AiError } from "../../utils/ai";
+import { buildOpeningPrompt } from "../../utils/aiPrompts";
+import type { AiMode } from "../../types";
+
+const textareaStyle = {
+  width: "100%",
+  boxSizing: "border-box" as const,
+  background: "#070a14",
+  border: "1px solid #1a2535",
+  color: "#8ab0cc",
+  fontSize: 11,
+  fontFamily: "inherit",
+  borderRadius: 4,
+  padding: "8px 10px",
+  resize: "vertical" as const,
+  outline: "none",
+  lineHeight: 1.7,
+};
+
+type Props = {
+  aiMode: AiMode;
+  byokLocalKey: string;
+  initialWorld?: string;
+  initialCharacters?: string;
+  result: string;
+  onResult: (text: string) => void;
+  loading: boolean;
+  onLoading: (v: boolean) => void;
+  error: string;
+  onError: (v: string) => void;
+  onInsert: (text: string) => void;
+  onAppend: (text: string) => void;
+};
+
+export function OpeningPanel({
+  aiMode,
+  byokLocalKey,
+  initialWorld = "",
+  initialCharacters = "",
+  result,
+  onResult,
+  loading,
+  onLoading,
+  error,
+  onError,
+  onInsert,
+  onAppend,
+}: Props) {
+  const [worldInput, setWorldInput] = useState(initialWorld);
+  const [characterInput, setCharacterInput] = useState(initialCharacters);
+  const [freeInstruction, setFreeInstruction] = useState("");
+
+  // Settings が更新されたとき、未編集なら反映する
+  const [prevInitialWorld, setPrevInitialWorld] = useState(initialWorld);
+  const [prevInitialCharacters, setPrevInitialCharacters] = useState(initialCharacters);
+  if (initialWorld !== prevInitialWorld) {
+    setPrevInitialWorld(initialWorld);
+    if (worldInput === prevInitialWorld) setWorldInput(initialWorld);
+  }
+  if (initialCharacters !== prevInitialCharacters) {
+    setPrevInitialCharacters(initialCharacters);
+    if (characterInput === prevInitialCharacters) setCharacterInput(initialCharacters);
+  }
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const prompt = buildOpeningPrompt(worldInput, characterInput, freeInstruction);
+      return callAnthropic(prompt, 800, aiMode, byokLocalKey);
+    },
+    onMutate: () => {
+      onResult("");
+      onError("");
+      onLoading(true);
+    },
+    onSuccess: (text) => onResult(text),
+    onError: (e) => {
+      onError(e instanceof AiError ? e.message : "不明なエラーが発生しました");
+    },
+    onSettled: () => onLoading(false),
+    retry: (count, e) => {
+      if (e instanceof AiError) return false;
+      return count < 2;
+    },
+    retryDelay: (attempt) => [1000, 2000][attempt] ?? 2000,
+  });
+
+  const canRun = !loading && (worldInput.trim() || characterInput.trim() || freeInstruction.trim());
+
+  return (
+    <div style={{ borderBottom: "1px solid #1a2535", paddingBottom: 16 }}>
+      <div style={{ fontSize: 10, letterSpacing: 2, color: "#4a6fa5", marginBottom: 10 }}>✦ 書き出し生成</div>
+
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ fontSize: 10, color: "#3a5570", marginBottom: 4, letterSpacing: 1 }}>世界観</div>
+        <textarea
+          value={worldInput}
+          onChange={e => setWorldInput(e.target.value)}
+          placeholder="舞台・時代・雰囲気など…"
+          rows={2}
+          style={textareaStyle}
+        />
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ fontSize: 10, color: "#3a5570", marginBottom: 4, letterSpacing: 1 }}>登場人物</div>
+        <textarea
+          value={characterInput}
+          onChange={e => setCharacterInput(e.target.value)}
+          placeholder="主人公・関係者など…"
+          rows={2}
+          style={textareaStyle}
+        />
+      </div>
+
+      <div style={{ marginBottom: 10 }}>
+        <div style={{ fontSize: 10, color: "#3a5570", marginBottom: 4, letterSpacing: 1 }}>自由指示</div>
+        <textarea
+          value={freeInstruction}
+          onChange={e => setFreeInstruction(e.target.value)}
+          placeholder="ジャンル・視点・トーンなど…"
+          rows={2}
+          style={textareaStyle}
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        <button
+          onClick={() => mutation.mutate()}
+          disabled={!canRun}
+          style={{
+            padding: "4px 12px",
+            background: canRun ? "rgba(74,111,165,0.1)" : "rgba(74,111,165,0.05)",
+            border: "1px solid #2a4060",
+            color: canRun ? "#4a6fa5" : "#2a4060",
+            cursor: canRun ? "pointer" : "default",
+            borderRadius: 4,
+            fontSize: 11,
+            fontFamily: "inherit",
+            letterSpacing: 1,
+          }}
+        >
+          {loading ? "生成中…" : error ? "再試行" : "書き出しを生成"}
+        </button>
+        {result && (
+          <button
+            onClick={() => onResult("")}
+            style={{ padding: "4px 10px", background: "transparent", border: "1px solid #1e2d42", color: "#3a5570", cursor: "pointer", borderRadius: 4, fontSize: 11, fontFamily: "inherit" }}
+          >
+            クリア
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div style={{ marginTop: 6, fontSize: 11, color: "#e05555" }}>⚠ {error}</div>
+      )}
+
+      {result && (
+        <div style={{ marginTop: 8, padding: "10px 12px", background: "#070a14", border: "1px solid #1a2535", borderRadius: 4, fontSize: 12, color: "#8ab0cc", lineHeight: 1.9, whiteSpace: "pre-wrap" }}>
+          {result}
+          <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
+            <button
+              onClick={() => onInsert(result)}
+              style={{ padding: "3px 10px", background: "rgba(74,111,165,0.15)", border: "1px solid #2a4060", color: "#4a8fcc", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}
+            >
+              先頭に挿入
+            </button>
+            <button
+              onClick={() => onAppend(result)}
+              style={{ padding: "3px 10px", background: "rgba(42,128,96,0.15)", border: "1px solid #2a8060", color: "#5ab090", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}
+            >
+              追記
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/stores/useStudioStore.ts
+++ b/src/stores/useStudioStore.ts
@@ -207,9 +207,9 @@ export interface StudioState {
 // Store
 // ---------------------------------------------------------------------------
 
-const aiResultsInit: AiResults = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" };
-const aiErrorsInit: AiErrors = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" };
-const aiLoadingInit: AiLoading = { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false };
+const aiResultsInit: AiResults = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "", opening: "" };
+const aiErrorsInit: AiErrors = { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "", opening: "" };
+const aiLoadingInit: AiLoading = { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false, opening: false };
 
 function resetAiWorkspaceState() {
   return {
@@ -939,9 +939,9 @@ export function resetStudioStore() {
     aiFloat: false,
     aiWide: false,
     aiPanelWidth: 360,
-    aiResults: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" },
-    aiErrors: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "" },
-    aiLoading: { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false },
+    aiResults: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "", opening: "" },
+    aiErrors: { polish: "", hint: "", check: "", continue: "", synopsis: "", worldExpand: "", characterExpand: "", themeExpand: "", freeInstruct: "", opening: "" },
+    aiLoading: { polish: false, hint: false, check: false, continue: false, synopsis: false, worldExpand: false, characterExpand: false, themeExpand: false, freeInstruct: false, opening: false },
     aiApplied: {},
     hintApplied: {},
     aiHistory: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type AiResults = {
   characterExpand: string;
   themeExpand: string;
   freeInstruct: string;
+  opening: string;
 };
 
 export type AiErrors = Record<keyof AiResults, string>;

--- a/src/utils/aiPrompts.ts
+++ b/src/utils/aiPrompts.ts
@@ -2,6 +2,19 @@ import type { Settings } from "../types";
 
 const MANUSCRIPT_CONTEXT_LIMIT = 1200;
 
+export function buildOpeningPrompt(
+  worldInput: string,
+  characterInput: string,
+  freeInstruction: string,
+): string {
+  const parts = ["小説の書き出しを日本語で生成してください。"];
+  if (worldInput.trim()) parts.push(`【世界観】\n${worldInput.trim()}`);
+  if (characterInput.trim()) parts.push(`【登場人物】\n${characterInput.trim()}`);
+  if (freeInstruction.trim()) parts.push(`【指示】\n${freeInstruction.trim()}`);
+  parts.push("冒頭100〜300字の書き出しを1パターンのみ出力してください。余分な説明は不要です。");
+  return parts.join("\n\n");
+}
+
 export function buildSettingExpansionPrompt(
   settingsTab: "world" | "characters" | "theme",
   settings: Settings,


### PR DESCRIPTION
## Summary
This PR adds a new "Opening Panel" feature to the AI assistant that generates novel opening sentences based on user-provided world-building, character information, and free-form instructions.

## Key Changes
- **New Component**: Created `OpeningPanel.tsx` component that provides three input fields (world, characters, free instruction) and generates opening sentences using the Anthropic API
- **Prompt Builder**: Added `buildOpeningPrompt()` function in `aiPrompts.ts` to construct prompts for opening generation with structured input sections
- **State Management**: Extended AI state types (`AiResults`, `AiErrors`, `AiLoading`) to include `opening` field for tracking generation results, errors, and loading states
- **Integration**: Integrated `OpeningPanel` into `AiAssistant.tsx` with proper state management, error handling, and result insertion/append functionality
- **UI Features**: 
  - Three textarea inputs for world-building context, character descriptions, and free instructions
  - Generate button that's disabled when all inputs are empty
  - Clear button to reset results
  - Insert at beginning and append buttons to add generated text to the manuscript
  - Error display and retry capability

## Implementation Details
- The component syncs with parent settings state, automatically updating inputs when settings change (if user hasn't manually edited them)
- Uses React Query's `useMutation` hook for API calls with retry logic (max 2 retries with exponential backoff)
- Generates 100-300 character opening sentences with minimal explanation
- Maintains consistent styling with existing AI panels (dark theme with blue accents)
- Integrates with AI history tracking for generated content

https://claude.ai/code/session_0153V8qBoxhvm9zFY3BsDob9