### PR TITLE
Remove feature flags and enable BYOK modes by default

### DIFF
--- a/api/anthropic.ts
+++ b/api/anthropic.ts
@@ -48,7 +48,13 @@ function validateMode(mode: unknown): AiMode {
 async function resolveApiKey(mode: AiMode, req: VercelRequest, userId: string): Promise<string> {
   if (mode === "byok_local") {
     const byokKey = req.headers["x-byok-key"];
-    if (typeof byokKey !== "string" || !byokKey.startsWith("sk-ant-")) {
+    if (
+      typeof byokKey !== "string" ||
+      !byokKey.startsWith("sk-ant-") ||
+      byokKey.length < 40 ||
+      byokKey.length > 256 ||
+      !/^[\x21-\x7E]+$/.test(byokKey)
+    ) {
       throw Object.assign(new Error("Invalid BYOK key format"), { status: 400 });
     }
     return byokKey;

--- a/api/byok-save.ts
+++ b/api/byok-save.ts
@@ -14,7 +14,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const { apiKey } = req.body as { apiKey?: unknown };
-  if (typeof apiKey !== "string" || !apiKey.startsWith("sk-ant-")) {
+  if (
+    typeof apiKey !== "string" ||
+    !apiKey.startsWith("sk-ant-") ||
+    apiKey.length < 40 ||
+    apiKey.length > 256 ||
+    !/^[\x21-\x7E]+$/.test(apiKey)
+  ) {
     return res.status(400).json({ error: "Invalid API key format" });
   }
 

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -28,8 +28,9 @@ export const AiAssistant: React.FC = () => {
     aiLoading, setAiLoading, aiApplied, setAiApplied,
     hintApplied, setHintApplied, manuscriptText,
     handleManuscriptChange, settings, selectedScene, addAiHistory,
-    aiMode, byokLocalKey,
+    aiMode, byokLocalKey, setTab,
   } = useStudio();
+  const goByok = () => setTab("prefs");
   const [freeText, setFreeText] = useState("");
   const [resizing, setResizing] = useState(false);
   const panelMinWidth = 280;
@@ -160,6 +161,7 @@ export const AiAssistant: React.FC = () => {
                 onError={t => setAiErrors(e => ({ ...e, opening: t }))}
                 onInsert={text => handleManuscriptChange(text + (manuscriptText ? "\n\n" + manuscriptText : ""))}
                 onAppend={text => handleManuscriptChange(manuscriptText + (manuscriptText ? "\n\n" : "") + text)}
+                onGoByok={goByok}
               />
               {/* 自由指示パネル */}
               <div style={{ borderBottom: "1px solid #1a2535", paddingBottom: 16 }}>
@@ -202,7 +204,17 @@ export const AiAssistant: React.FC = () => {
                   )}
                 </div>
                 {aiErrors.freeInstruct && (
-                  <div style={{ marginTop: 6, fontSize: 11, color: "#e05555" }}>⚠ {aiErrors.freeInstruct}</div>
+                  <div style={{ marginTop: 6, fontSize: 11, color: "#e05555", display: "flex", flexDirection: "column", gap: 4 }}>
+                    <span>⚠ {aiErrors.freeInstruct}</span>
+                    {aiMode === "standard" && aiErrors.freeInstruct.includes("上限に達しました") && (
+                      <button
+                        onClick={goByok}
+                        style={{ alignSelf: "flex-start", padding: "4px 10px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}
+                      >
+                        APIキーを設定してBYOKで続ける →
+                      </button>
+                    )}
+                  </div>
                 )}
                 {aiResults.freeInstruct && (
                   <div style={{ marginTop: 8, padding: "10px 12px", background: "#070a14", border: "1px solid #1a2535", borderRadius: 4, fontSize: 12, color: "#8ab0cc", lineHeight: 1.9, whiteSpace: "pre-wrap" }}>
@@ -222,6 +234,7 @@ export const AiAssistant: React.FC = () => {
               <PolishPanel
                 aiMode={aiMode}
                 byokLocalKey={byokLocalKey}
+                onGoByok={goByok}
                 manuscriptText={manuscriptText}
                 result={aiResults.polish}
                 onResult={t => {
@@ -251,6 +264,7 @@ export const AiAssistant: React.FC = () => {
               <HintPanel
                 aiMode={aiMode}
                 byokLocalKey={byokLocalKey}
+                onGoByok={goByok}
                 result={aiResults.hint}
                 onResult={t => {
                   setAiResults(r => ({ ...r, hint: t }));
@@ -278,6 +292,7 @@ export const AiAssistant: React.FC = () => {
               <AiPanel
                 aiMode={aiMode}
                 byokLocalKey={byokLocalKey}
+                onGoByok={goByok}
                 label="矛盾チェック"
                 result={aiResults.check}
                 onResult={t => { setAiResults(r => ({ ...r, check: t })); if (t) addAiHistory("矛盾チェック", t, selectedScene.title, selectedScene.id); }}

--- a/src/components/ai/AiPanel.tsx
+++ b/src/components/ai/AiPanel.tsx
@@ -16,6 +16,7 @@ type AiPanelProps = {
   onError: (value: string) => void;
   aiMode?: AiMode;
   byokLocalKey?: string;
+  onGoByok?: () => void;
 };
 
 export function AiPanel({
@@ -31,6 +32,7 @@ export function AiPanel({
   onError,
   aiMode = "standard",
   byokLocalKey = "",
+  onGoByok,
 }: AiPanelProps) {
   const onAppendRef = useRef(onAppend);
   useEffect(() => {
@@ -105,8 +107,26 @@ export function AiPanel({
       </div>
 
       {error && (
-        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555", display: "flex", alignItems: "center", gap: 6 }}>
+        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555", display: "flex", flexDirection: "column", gap: 4 }}>
           <span>⚠ {error}</span>
+          {onGoByok && aiMode === "standard" && error.includes("上限に達しました") && (
+            <button
+              onClick={onGoByok}
+              style={{
+                alignSelf: "flex-start",
+                padding: "4px 10px",
+                background: "rgba(74,111,165,0.15)",
+                border: "1px solid #4a6fa5",
+                color: "#7ab3e0",
+                cursor: "pointer",
+                borderRadius: 3,
+                fontSize: 11,
+                fontFamily: "inherit",
+              }}
+            >
+              APIキーを設定してBYOKで続ける →
+            </button>
+          )}
         </div>
       )}
 

--- a/src/components/ai/HintPanel.tsx
+++ b/src/components/ai/HintPanel.tsx
@@ -17,6 +17,7 @@ type HintPanelProps = {
   onInsert: (value: string) => void;
   aiMode?: AiMode;
   byokLocalKey?: string;
+  onGoByok?: () => void;
 };
 
 export function HintPanel({
@@ -33,6 +34,7 @@ export function HintPanel({
   onInsert,
   aiMode = "standard",
   byokLocalKey = "",
+  onGoByok,
 }: HintPanelProps) {
   const hints = useMemo(() => {
     if (!result) return null;
@@ -101,7 +103,14 @@ export function HintPanel({
       </button>
 
       {error && (
-        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555" }}>⚠ {error}</div>
+        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555", display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>⚠ {error}</span>
+          {onGoByok && aiMode === "standard" && error.includes("上限に達しました") && (
+            <button onClick={onGoByok} style={{ alignSelf: "flex-start", padding: "4px 10px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>
+              APIキーを設定してBYOKで続ける →
+            </button>
+          )}
+        </div>
       )}
 
       {result && !hints && (

--- a/src/components/ai/OpeningPanel.tsx
+++ b/src/components/ai/OpeningPanel.tsx
@@ -32,6 +32,7 @@ type Props = {
   onError: (v: string) => void;
   onInsert: (text: string) => void;
   onAppend: (text: string) => void;
+  onGoByok?: () => void;
 };
 
 export function OpeningPanel({
@@ -47,6 +48,7 @@ export function OpeningPanel({
   onError,
   onInsert,
   onAppend,
+  onGoByok,
 }: Props) {
   const [worldInput, setWorldInput] = useState(initialWorld);
   const [characterInput, setCharacterInput] = useState(initialCharacters);
@@ -154,7 +156,14 @@ export function OpeningPanel({
       </div>
 
       {error && (
-        <div style={{ marginTop: 6, fontSize: 11, color: "#e05555" }}>⚠ {error}</div>
+        <div style={{ marginTop: 6, fontSize: 11, color: "#e05555", display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>⚠ {error}</span>
+          {onGoByok && aiMode === "standard" && error.includes("上限に達しました") && (
+            <button onClick={onGoByok} style={{ alignSelf: "flex-start", padding: "4px 10px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>
+              APIキーを設定してBYOKで続ける →
+            </button>
+          )}
+        </div>
       )}
 
       {result && (

--- a/src/components/ai/PolishPanel.tsx
+++ b/src/components/ai/PolishPanel.tsx
@@ -16,6 +16,7 @@ type PolishPanelProps = {
   onApplied: Dispatch<SetStateAction<AppliedState>>;
   aiMode?: AiMode;
   byokLocalKey?: string;
+  onGoByok?: () => void;
 };
 
 export function PolishPanel({
@@ -31,6 +32,7 @@ export function PolishPanel({
   onApplied,
   aiMode = "standard",
   byokLocalKey = "",
+  onGoByok,
 }: PolishPanelProps) {
   const suggestions = useMemo(() => {
     if (!result) return null;
@@ -86,7 +88,14 @@ export function PolishPanel({
       </button>
 
       {error && (
-        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555" }}>⚠ {error}</div>
+        <div style={{ marginTop: 8, fontSize: 11, color: "#e05555", display: "flex", flexDirection: "column", gap: 4 }}>
+          <span>⚠ {error}</span>
+          {onGoByok && aiMode === "standard" && error.includes("上限に達しました") && (
+            <button onClick={onGoByok} style={{ alignSelf: "flex-start", padding: "4px 10px", background: "rgba(74,111,165,0.15)", border: "1px solid #4a6fa5", color: "#7ab3e0", cursor: "pointer", borderRadius: 3, fontSize: 11, fontFamily: "inherit" }}>
+              APIキーを設定してBYOKで続ける →
+            </button>
+          )}
+        </div>
       )}
 
       {result && !suggestions && (

--- a/src/components/views/PrefsView.tsx
+++ b/src/components/views/PrefsView.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { useStudio } from "../../contexts/StudioContext";
-import { featureFlags } from "../../utils/featureFlags";
 import { testByokKey, removeByokLocalKey } from "../../utils/byokLocal";
 import { useCredits } from "../../hooks/useCredits";
 import { useUserProfile } from "../../hooks/useUserProfile";
@@ -100,8 +99,7 @@ function PlanStatusSection({
           <CreditBar label="今月" used={credits.monthlyUsed} limit={credits.monthlyLimit} />
           {atDailyLimit && (
             <div style={{ marginTop: 6, fontSize: 11, color: "#c06060" }}>
-              1日の上限に達しました。
-              {(featureFlags.byokLocal || featureFlags.byokCloud) && "BYOKモードへの切り替えをご検討ください。"}
+              1日の上限に達しました。BYOKモードへの切り替えをご検討ください。
             </div>
           )}
         </div>
@@ -109,26 +107,6 @@ function PlanStatusSection({
 
       {/* 広告プレースホルダー（Free のみ） */}
       {plan === "free" && <AdPlaceholder />}
-
-      {/* Upgrade CTA（Free のみ） */}
-      {plan === "free" && (
-        <button
-          disabled
-          title="近日公開予定"
-          style={{
-            padding: "8px 12px",
-            background: "transparent",
-            border: "1px solid #2a4060",
-            borderRadius: 4,
-            color: "#3a5570",
-            fontSize: 12,
-            fontFamily: "inherit",
-            cursor: "not-allowed",
-          }}
-        >
-          Pro プランにアップグレード
-        </button>
-      )}
     </div>
   );
 }
@@ -142,8 +120,6 @@ export const PrefsView: React.FC = () => {
   const [showKey, setShowKey] = useState(false);
   const [testStatus, setTestStatus] = useState<"idle" | "testing" | "ok" | "error">("idle");
   const [testError, setTestError] = useState("");
-
-  const hasAnyByok = featureFlags.byokLocal || featureFlags.byokCloud;
 
   async function handleTestByok() {
     const key = aiMode === "byok_local" ? byokLocalKey : byokInput;
@@ -214,35 +190,29 @@ export const PrefsView: React.FC = () => {
         </div>
 
         {/* AI設定 */}
-        {hasAnyByok && (
-          <div style={{ borderTop: "1px solid #1a2535", paddingTop: 20 }}>
-            <div style={sectionLabel}>AI利用モード</div>
+        <div style={{ borderTop: "1px solid #1a2535", paddingTop: 20 }}>
+          <div style={sectionLabel}>AI利用モード</div>
 
-            <div style={{ display: "flex", gap: 8, flexDirection: "column" }}>
-              <button onClick={() => setAiMode("standard")} style={modeBtn(aiMode === "standard")}>
-                スタンダード（運営サーバー経由）
-              </button>
-              {featureFlags.byokLocal && (
-                <button onClick={() => setAiMode("byok_local")} style={modeBtn(aiMode === "byok_local")}>
-                  BYOK ローカル（端末保持）
-                </button>
-              )}
-              {featureFlags.byokCloud && (
-                <button onClick={() => setAiMode("byok_cloud")} style={modeBtn(aiMode === "byok_cloud")}>
-                  BYOK クラウド（暗号化保存）
-                </button>
-              )}
-            </div>
-            <div style={{ fontSize: 10, color: "#2a4060", marginTop: 6 }}>
-              {aiMode === "standard" && "運営のAPIキーを使用します。クレジットを消費します。"}
-              {aiMode === "byok_local" && "自分のAPIキーを端末にのみ保存します。クレジットを消費しません。"}
-              {aiMode === "byok_cloud" && "自分のAPIキーを暗号化してクラウドに保存します。複数端末で利用できます。"}
-            </div>
+          <div style={{ display: "flex", gap: 8, flexDirection: "column" }}>
+            <button onClick={() => setAiMode("standard")} style={modeBtn(aiMode === "standard")}>
+              スタンダード（運営サーバー経由）
+            </button>
+            <button onClick={() => setAiMode("byok_local")} style={modeBtn(aiMode === "byok_local")}>
+              BYOK ローカル（端末保持）
+            </button>
+            <button onClick={() => setAiMode("byok_cloud")} style={modeBtn(aiMode === "byok_cloud")}>
+              BYOK クラウド（暗号化保存）
+            </button>
           </div>
-        )}
+          <div style={{ fontSize: 10, color: "#2a4060", marginTop: 6 }}>
+            {aiMode === "standard" && "運営のAPIキーを使用します。クレジットを消費します。"}
+            {aiMode === "byok_local" && "自分のAPIキーを端末にのみ保存します。クレジットを消費しません。"}
+            {aiMode === "byok_cloud" && "自分のAPIキーを暗号化してクラウドに保存します。複数端末で利用できます。"}
+          </div>
+        </div>
 
         {/* BYOK ローカルキー入力 */}
-        {aiMode === "byok_local" && featureFlags.byokLocal && (
+        {aiMode === "byok_local" && (
           <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
             <div style={sectionLabel}>Anthropic APIキー</div>
             {byokLocalKey ? (
@@ -284,7 +254,7 @@ export const PrefsView: React.FC = () => {
         )}
 
         {/* BYOK クラウドキー UI */}
-        {aiMode === "byok_cloud" && featureFlags.byokCloud && (
+        {aiMode === "byok_cloud" && (
           <ByokCloudSection profile={profile} />
         )}
 

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,4 +1,0 @@
-export const featureFlags = {
-  byokLocal: import.meta.env.VITE_ENABLE_BYOK_LOCAL === "true",
-  byokCloud: import.meta.env.VITE_ENABLE_BYOK_CLOUD === "true",
-} as const;

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,26 @@
 {
   "rewrites": [
     { "source": "/api/anthropic/v1/messages", "destination": "/api/anthropic" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://partner.googleadservices.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; img-src 'self' data: https:; frame-src https://ko-fi.com; object-src 'none'; base-uri 'self'"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
This PR removes the feature flag system that conditionally enabled BYOK (Bring Your Own Key) modes and makes both BYOK Local and BYOK Cloud features available by default. It also adds user-friendly shortcuts to switch to BYOK mode when hitting API rate limits.

## Key Changes

- **Removed feature flags**: Deleted `src/utils/featureFlags.ts` and removed all conditional rendering based on `featureFlags.byokLocal` and `featureFlags.byokCloud`
- **Always-enabled BYOK modes**: Both BYOK Local and BYOK Cloud options are now always available in the AI mode selector
- **Removed upgrade CTA**: Deleted the disabled "Pro プランにアップグレード" button from the preferences view
- **Rate limit recovery flow**: Added `onGoByok` callback to AI panels (AiPanel, PolishPanel, HintPanel, OpeningPanel) that displays a button to switch to BYOK mode when users encounter "上限に達しました" (limit reached) errors in standard mode
- **Enhanced error messages**: Updated error display in multiple panels to show a helpful call-to-action button when rate limits are hit
- **Security improvements**: Added comprehensive security headers to `vercel.json` including CSP, X-Frame-Options, and other protective headers
- **API key validation**: Strengthened validation for BYOK API keys in both `api/anthropic.ts` and `api/byok-save.ts` with length checks (40-256 chars) and ASCII character validation

## Implementation Details

- The `onGoByok` callback is passed through the component hierarchy from `AiAssistant` down to individual panels, allowing users to navigate to preferences when needed
- Error messages now conditionally show the BYOK switch button only when: `onGoByok` is provided, user is in "standard" mode, and the error message contains "上限に達しました"
- API key validation now checks for proper format, length, and character set to prevent invalid keys from being processed

https://claude.ai/code/session_01K2jRfzb2YZfhWDv12BeKiN