### PR TITLE
fix(#196): ALLOW_BYOK_* サーバーゲートを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,6 @@ ANTHROPIC_API_KEY=sk-ant-...
 SUPABASE_URL=https://...
 SUPABASE_SERVICE_ROLE_KEY=...          # admin 操作用
 BYOK_ENCRYPTION_KEY=...                # 64文字 hex（AES-256-GCM 鍵）
-ALLOW_BYOK_LOCAL=true                  # BYOK ローカルモードを許可
-ALLOW_BYOK_CLOUD=true                  # BYOK クラウドモードを許可
 PLAN_FREE_DAILY_LIMIT=10               # 省略時デフォルト
 PLAN_FREE_MONTHLY_LIMIT=100
 PLAN_PRO_DAILY_LIMIT=100
@@ -63,8 +61,6 @@ PLAN_PRO_MONTHLY_LIMIT=2000
 **クライアント側（ビルド時 `.env`）**
 
 ```env
-VITE_ENABLE_BYOK_LOCAL=true            # BYOK ローカル UI を表示
-VITE_ENABLE_BYOK_CLOUD=true            # BYOK クラウド UI を表示
 VITE_KOFI_URL=https://ko-fi.com/...    # ドネーションボタン（未設定で非表示）
 VITE_AD_CLIENT=...                     # AdSense クライアント ID（未設定でプレースホルダー）
 VITE_AD_SLOT=...                       # AdSense スロット ID

--- a/api/anthropic.ts
+++ b/api/anthropic.ts
@@ -33,12 +33,6 @@ function getClientIp(req: VercelRequest): string {
 }
 
 function validateMode(mode: unknown): AiMode {
-  if (mode === "byok_local" && process.env.ALLOW_BYOK_LOCAL !== "true") {
-    throw Object.assign(new Error("BYOK local mode is not enabled"), { status: 403 });
-  }
-  if (mode === "byok_cloud" && process.env.ALLOW_BYOK_CLOUD !== "true") {
-    throw Object.assign(new Error("BYOK cloud mode is not enabled"), { status: 403 });
-  }
   if (mode !== "standard" && mode !== "byok_local" && mode !== "byok_cloud") {
     return "standard";
   }


### PR DESCRIPTION
Pro廃止・OSS方針に伴いBYOKは常時有効とする。
validateMode() から ALLOW_BYOK_LOCAL/CLOUD の環境変数チェックを削除し、 UIで常時表示したBYOKボタンが403エラーを返す壊れたフローを解消する。
CLAUDE.mdの不要な環境変数記述も合わせて削除。

https://claude.ai/code/session_01K2jRfzb2YZfhWDv12BeKiN