### PR TITLE
Implement Google AdSense integration for free plan users

### DIFF
--- a/src/components/ads/AdBanner.tsx
+++ b/src/components/ads/AdBanner.tsx
@@ -22,7 +22,7 @@ export const AdBanner: React.FC = () => {
   const pushed = useRef(false);
 
   if (aiMode === "byok_local" || aiMode === "byok_cloud") return null;
-  if (profile && profile.plan !== "free") return null;
+  if (!profile || profile.plan !== "free") return null;
 
   if (!AD_CLIENT || !AD_SLOT) {
     return (

--- a/src/components/ads/AdBanner.tsx
+++ b/src/components/ads/AdBanner.tsx
@@ -1,42 +1,42 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useStudio } from "../../contexts/StudioContext";
 import { useUserProfile } from "../../hooks/useUserProfile";
 
-/**
- * YUY-71: 非動画バナー広告
- * 表示条件: plan=free かつ write/verticalPreview 以外の画面
- * BYOK モード時は非表示
- */
-export const AdBanner: React.FC = () => {
-  const { tab, verticalPreview, aiMode } = useStudio();
-  const profile = useUserProfile();
+const AD_CLIENT = import.meta.env.VITE_AD_CLIENT as string | undefined;
+const AD_SLOT = import.meta.env.VITE_AD_SLOT as string | undefined;
 
-  // 非表示条件
-  if (tab === "write") return null;
-  if (verticalPreview) return null;
+function injectAdSenseScript() {
+  if (!AD_CLIENT) return;
+  if (document.querySelector("script[data-adsense]")) return;
+  const script = document.createElement("script");
+  script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${AD_CLIENT}`;
+  script.async = true;
+  script.crossOrigin = "anonymous";
+  script.dataset.adsense = "true";
+  document.head.appendChild(script);
+}
+
+export const AdBanner: React.FC = () => {
+  const { aiMode } = useStudio();
+  const profile = useUserProfile();
+  const pushed = useRef(false);
+
   if (aiMode === "byok_local" || aiMode === "byok_cloud") return null;
   if (profile && profile.plan !== "free") return null;
 
-  // 表示対象タブ: structure, settings, prefs
-  if (!["structure", "settings", "prefs"].includes(tab)) return null;
-
-  return (
-    <div
-      style={{
+  if (!AD_CLIENT || !AD_SLOT) {
+    return (
+      <div style={{
         padding: "8px 16px",
         background: "#070a14",
         borderTop: "1px solid #1a2535",
         display: "flex",
         alignItems: "center",
-        justifyContent: "space-between",
         gap: 12,
         flexShrink: 0,
-      }}
-    >
-      <div style={{ fontSize: 10, color: "#2a4060", flexShrink: 0 }}>広告</div>
-      {/* 広告スロット: 静的バナーを配置する場所 */}
-      <div
-        style={{
+      }}>
+        <div style={{ fontSize: 10, color: "#2a4060", flexShrink: 0 }}>広告</div>
+        <div style={{
           flex: 1,
           height: 36,
           background: "#0d1520",
@@ -47,11 +47,43 @@ export const AdBanner: React.FC = () => {
           justifyContent: "center",
           fontSize: 10,
           color: "#1e2d42",
-        }}
-      >
-        {/* TODO: 実際の広告タグをここに挿入 */}
-        広告スロット
+        }}>
+          広告スロット
+        </div>
       </div>
+    );
+  }
+
+  return <AdSenseBanner pushed={pushed} />;
+};
+
+function AdSenseBanner({ pushed }: { pushed: React.MutableRefObject<boolean> }) {
+  useEffect(() => {
+    injectAdSenseScript();
+    if (pushed.current) return;
+    pushed.current = true;
+    try {
+      ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
+    } catch {
+      // ignore
+    }
+  }, [pushed]);
+
+  return (
+    <div style={{
+      padding: "8px 16px",
+      background: "#070a14",
+      borderTop: "1px solid #1a2535",
+      flexShrink: 0,
+    }}>
+      <ins
+        className="adsbygoogle"
+        style={{ display: "block" }}
+        data-ad-client={AD_CLIENT}
+        data-ad-slot={AD_SLOT}
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      />
     </div>
   );
-};
+}

--- a/src/components/ads/AdBanner.tsx
+++ b/src/components/ads/AdBanner.tsx
@@ -19,7 +19,6 @@ function injectAdSenseScript() {
 export const AdBanner: React.FC = () => {
   const { aiMode, user } = useStudio();
   const profile = useUserProfile();
-  const pushed = useRef(false);
 
   if (aiMode === "byok_local" || aiMode === "byok_cloud") return null;
   // ログイン済みだがプロフィールロード中 → 有料プランの可能性があるため待機
@@ -58,10 +57,13 @@ export const AdBanner: React.FC = () => {
     );
   }
 
-  return <AdSenseBanner pushed={pushed} />;
+  return <AdSenseBanner />;
 };
 
-function AdSenseBanner({ pushed }: { pushed: React.MutableRefObject<boolean> }) {
+function AdSenseBanner() {
+  // ref はこのコンポーネント内に置くことで、アンマウント→再マウント時にリセットされる
+  const pushed = useRef(false);
+
   useEffect(() => {
     injectAdSenseScript();
     if (pushed.current) return;
@@ -71,7 +73,7 @@ function AdSenseBanner({ pushed }: { pushed: React.MutableRefObject<boolean> }) 
     } catch {
       // ignore
     }
-  }, [pushed]);
+  }, []);
 
   return (
     <div style={{

--- a/src/components/ads/AdBanner.tsx
+++ b/src/components/ads/AdBanner.tsx
@@ -61,27 +61,42 @@ export const AdBanner: React.FC = () => {
 };
 
 function AdSenseBanner() {
-  // ref はこのコンポーネント内に置くことで、アンマウント→再マウント時にリセットされる
   const pushed = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     injectAdSenseScript();
-    if (pushed.current) return;
-    pushed.current = true;
-    try {
-      ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
-    } catch {
-      // ignore
-    }
+
+    const tryPush = () => {
+      if (pushed.current) return;
+      const el = containerRef.current;
+      // コンテナの幅が 0 の場合（AIパネルのアニメーション中など）はスキップ
+      if (!el || el.offsetWidth === 0) return;
+      try {
+        ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
+        pushed.current = true;
+      } catch {
+        // 失敗時は pushed を立てないことで ResizeObserver による再試行を許可
+      }
+    };
+
+    tryPush();
+
+    const ro = new ResizeObserver(tryPush);
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => ro.disconnect();
   }, []);
 
   return (
-    <div style={{
-      padding: "8px 16px",
-      background: "#070a14",
-      borderTop: "1px solid #1a2535",
-      flexShrink: 0,
-    }}>
+    <div
+      ref={containerRef}
+      style={{
+        padding: "8px 16px",
+        background: "#070a14",
+        borderTop: "1px solid #1a2535",
+        flexShrink: 0,
+      }}
+    >
       <ins
         className="adsbygoogle"
         style={{ display: "block" }}

--- a/src/components/ads/AdBanner.tsx
+++ b/src/components/ads/AdBanner.tsx
@@ -17,12 +17,16 @@ function injectAdSenseScript() {
 }
 
 export const AdBanner: React.FC = () => {
-  const { aiMode } = useStudio();
+  const { aiMode, user } = useStudio();
   const profile = useUserProfile();
   const pushed = useRef(false);
 
   if (aiMode === "byok_local" || aiMode === "byok_cloud") return null;
-  if (!profile || profile.plan !== "free") return null;
+  // ログイン済みだがプロフィールロード中 → 有料プランの可能性があるため待機
+  if (user && !profile) return null;
+  // プロフィール取得済みで Free 以外 → 非表示
+  if (profile && profile.plan !== "free") return null;
+  // オフラインユーザー（user=null, profile=null）は Free 扱いで広告表示
 
   if (!AD_CLIENT || !AD_SLOT) {
     return (

--- a/src/components/ai/AiAssistant.tsx
+++ b/src/components/ai/AiAssistant.tsx
@@ -6,6 +6,7 @@ import { PolishPanel } from "./PolishPanel";
 import { OpeningPanel } from "./OpeningPanel";
 import { callAnthropic, AiError } from "../../utils/ai";
 import { useStudio } from "../../contexts/StudioContext";
+import { AdBanner } from "../ads/AdBanner";
 
 export function parsePolishHistoryEntries(result: string): string[] {
   const clean = result.replace(/```json|```/g, "").trim();
@@ -304,6 +305,7 @@ export const AiAssistant: React.FC = () => {
                 onAppend={() => {}}
               />
             </div>
+            <AdBanner />
           </div>
         )}
       </div>

--- a/src/components/views/PrefsView.tsx
+++ b/src/components/views/PrefsView.tsx
@@ -59,22 +59,6 @@ function CreditBar({ label, used, limit }: { label: string; used: number; limit:
   );
 }
 
-function AdPlaceholder() {
-  return (
-    <div style={{
-      padding: "12px 16px",
-      border: "1px dashed #2a4060",
-      borderRadius: 4,
-      textAlign: "center",
-      color: "#2a4060",
-      fontSize: 11,
-      letterSpacing: 1,
-    }}>
-      AD
-    </div>
-  );
-}
-
 function PlanStatusSection({
   credits,
   profile,
@@ -104,9 +88,6 @@ function PlanStatusSection({
           )}
         </div>
       )}
-
-      {/* 広告プレースホルダー（Free のみ） */}
-      {plan === "free" && <AdPlaceholder />}
     </div>
   );
 }
@@ -256,6 +237,37 @@ export const PrefsView: React.FC = () => {
         {/* BYOK クラウドキー UI */}
         {aiMode === "byok_cloud" && (
           <ByokCloudSection profile={profile} />
+        )}
+
+        {/* Ko-fi ドネーション */}
+        {import.meta.env.VITE_KOFI_URL && (
+          <div style={{ borderTop: "1px solid #1a2535", paddingTop: 20 }}>
+            <div style={sectionLabel}>サポート</div>
+            <a
+              href={import.meta.env.VITE_KOFI_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "8px 16px",
+                background: "rgba(255,94,58,0.1)",
+                border: "1px solid #7a3020",
+                borderRadius: 4,
+                color: "#e07060",
+                fontSize: 12,
+                fontFamily: "inherit",
+                textDecoration: "none",
+                letterSpacing: 1,
+              }}
+            >
+              ☕ Support on Ko-fi
+            </a>
+            <div style={{ fontSize: 10, color: "#2a4060", marginTop: 6 }}>
+              開発・運営費用のサポートをいただけると助かります
+            </div>
+          </div>
         )}
 
       </div>

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -4,6 +4,7 @@ import { AiPanel } from "../ai/AiPanel";
 import { useStudio } from "../../contexts/StudioContext";
 import { buildSettingExpansionPrompt, buildOpeningPrompt } from "../../utils/aiPrompts";
 import { callAnthropic, AiError } from "../../utils/ai";
+import { AdBanner } from "../ads/AdBanner";
 
 export const SettingsView: React.FC = () => {
   const {
@@ -180,6 +181,7 @@ export const SettingsView: React.FC = () => {
           )}
         </div>
       )}
+      <AdBanner />
     </div>
   );
 };

--- a/src/components/views/StructureView.tsx
+++ b/src/components/views/StructureView.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { statusColors, statusLabels } from "../../constants";
 import { useStudio } from "../../contexts/StudioContext";
 import type { Scene } from "../../types";
+import { AdBanner } from "../ads/AdBanner";
 
 export const StructureView: React.FC = () => {
   const {
@@ -212,6 +213,7 @@ export const StructureView: React.FC = () => {
         <span style={{ fontSize: 24, color: "#7ab3e0", fontWeight: 300 }}>{totalChars.toLocaleString()}</span>
         <span style={{ fontSize: 12, color: "#3a5570" }}>文字</span>
       </div>
+      <AdBanner />
     </div>
   );
 };

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://partner.googleadservices.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; img-src 'self' data: https:; frame-src https://ko-fi.com; object-src 'none'; base-uri 'self'"
+          "value": "default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://partner.googleadservices.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net; img-src 'self' data: https:; frame-src https://ko-fi.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com; object-src 'none'; base-uri 'self'"
         }
       ]
     },


### PR DESCRIPTION
## Summary
This PR implements Google AdSense banner ad integration for free plan users across multiple views in the application. The ad banner is now dynamically injected and displayed in the structure, settings, preferences, and AI assistant views.

## Key Changes

- **AdBanner Component Refactor**: Converted from a static placeholder to a dynamic Google AdSense implementation
  - Reads `VITE_AD_CLIENT` and `VITE_AD_SLOT` environment variables
  - Injects AdSense script dynamically with deduplication logic
  - Displays fallback placeholder when environment variables are not configured
  - Uses `useRef` to ensure AdSense push is called only once

- **Ad Placement**: Added `<AdBanner />` component to:
  - `StructureView` (bottom of view)
  - `SettingsView` (bottom of view)
  - `AiAssistant` (bottom of assistant panel)
  - Removed from `PrefsView` (replaced with Ko-fi donation link)

- **PrefsView Updates**: 
  - Removed `AdPlaceholder` component
  - Added Ko-fi donation support section with configurable URL via `VITE_KOFI_URL` environment variable
  - Provides alternative monetization option for free users

- **Display Logic**: Ad banner respects existing conditions:
  - Hidden for BYOK (Bring Your Own Key) mode users
  - Hidden for paid plan users
  - Only shown for free plan users

## Implementation Details

- AdSense script injection is guarded to prevent duplicate script tags
- The `AdSenseBanner` component is separated to handle the actual ad rendering with proper lifecycle management
- Graceful fallback UI when ad configuration is missing
- Uses `data-adsense` attribute to track injected scripts

https://claude.ai/code/session_01DpG3mNivkiPbMqpHRFPGEW