### PR TITLE
Add privacy policy links to PrefsView and App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,14 @@ export default function App() {
         DBログインすると端末間でデータを同期できます。<br />
         オフライン起動時は、この端末のローカル保存のみ利用します。
       </p>
+      <a
+        href="https://www.notion.so/36750786cdc380a8b2bdd4ca481f327f"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ fontSize: 11, color: "#2a4060", textDecoration: "none" }}
+      >
+        プライバシーポリシー
+      </a>
     </main>
   );
 

--- a/src/components/views/PrefsView.tsx
+++ b/src/components/views/PrefsView.tsx
@@ -270,6 +270,18 @@ export const PrefsView: React.FC = () => {
           </div>
         )}
 
+        {/* プライバシーポリシー */}
+        <div style={{ borderTop: "1px solid #1a2535", paddingTop: 20 }}>
+          <a
+            href="https://www.notion.so/36750786cdc380a8b2bdd4ca481f327f"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 11, color: "#2a4060", textDecoration: "none" }}
+          >
+            プライバシーポリシー
+          </a>
+        </div>
+
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Add privacy policy links to both the preferences view and the main app landing page, directing users to the privacy policy document hosted on Notion.

## Changes
- **PrefsView.tsx**: Added a new section with a privacy policy link at the bottom of the preferences panel, styled consistently with the existing UI (11px font, `#2a4060` color, no underline)
- **App.tsx**: Added a privacy policy link to the main app landing page below the login description text, using the same styling as the PrefsView link

Both links open the privacy policy in a new tab (`target="_blank"`) with appropriate security attributes (`rel="noopener noreferrer"`).

## Implementation Details
- Links point to: `https://www.notion.so/36750786cdc380a8b2bdd4ca481f327f`
- Consistent styling across both locations (font-size: 11px, color: #2a4060, no text-decoration)
- PrefsView link is separated with a top border for visual distinction
- Both links follow the existing design patterns in the codebase

https://claude.ai/code/session_012EM1PAWzGdhYpD6abz2jX1