### PR TITLE
feat: PWA manifest と Google Play (TWA) 対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="minato ws" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
     <title>minato Writing Studio</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -3,9 +3,9 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "YOUR_PACKAGE_NAME",
+      "package_name": "app.minato_ws.twa",
       "sha256_cert_fingerprints": [
-        "YOUR_SHA256_FINGERPRINT"
+        "REPLACE_WITH_SHA256_FROM_PLAY_CONSOLE"
       ]
     }
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "minato Writing Studio",
+  "short_name": "minato ws",
+  "description": "シーン管理・AI支援搭載の小説執筆アプリ",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0a0e1a",
+  "theme_color": "#0a0e1a",
+  "lang": "ja",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,12 @@
       "headers": [
         { "key": "X-Robots-Tag", "value": "noindex" }
       ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 変更内容

- `public/manifest.json` を追加（PWA 対応）
- `index.html` に manifest リンクを追加
- `public/.well-known/assetlinks.json` を追加（TWA / Google Play 紐づけ用）
- `vercel.json` に assetlinks.json の Content-Type ヘッダーを追加
- `public/ads.txt` を追加（AdSense 発行者 ID 確認用）
- ログイン画面・環境設定にプライバシーポリシーリンクを追加

## 残作業

- Play Console で SHA-256 フィンガープリントを取得後、`assetlinks.json` の `REPLACE_WITH_SHA256_FROM_PLAY_CONSOLE` を更新する
- PWABuilder で AAB を生成して Play Console にアップロード

---
_Generated by [Claude Code](https://claude.ai/code/session_012EM1PAWzGdhYpD6abz2jX1)_